### PR TITLE
resolve sidebar Firefox issue (#59)

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -73,7 +73,7 @@ const config = {
         },
         hide: {
           from: { opacity: "1" },
-          to: { opacity: "0", display: "none", visibility: "hidden" },
+          to: { opacity: "0", position: "absolute" },
         },
       },
       animation: {


### PR DESCRIPTION
> the reason for this is because Firefox [doesn't animate `display: none`](https://bugzilla.mozilla.org/show_bug.cgi?id=1264396) as a discrete property, because it would cancel out the animation. that behavior may change with [`transition-behavior: allow-discrete`](https://developer.mozilla.org/en-US/docs/Web/CSS/transition-behavior), which will be included in Firefox 129 next week. the solution is to animate the content in the sidebar to `position: absolute`, which has issues but works across Firefox and Chromium browsers