### PR TITLE
svg

### DIFF
--- a/src/components/article-creator/Editor.tsx
+++ b/src/components/article-creator/Editor.tsx
@@ -30,7 +30,7 @@ import {
   uploadBytes,
 } from "firebase/storage";
 import { buttonVariants } from "../ui/button";
-import { cn } from "@/lib/utils";
+import { cn, resolveUploadContentType } from "@/lib/utils";
 
 interface EditorImageData {
   file: { url?: string; storageRefFullPath?: string; [key: string]: unknown };
@@ -87,7 +87,9 @@ class CustomImage extends Image {
     // constrain the call at the boundary instead of widening the rest of the file.
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
     const settings = baseImageTool.prototype.renderSettings.call(typedTool);
-    const settingsArray = (Array.isArray(settings) ? settings : [settings]) as unknown[];
+    const settingsArray = (
+      Array.isArray(settings) ? settings : [settings]
+    ) as unknown[];
 
     return [
       {
@@ -96,7 +98,9 @@ class CustomImage extends Image {
         title: "Delete image",
         onActivate: () => {
           const { file } = typedTool._data;
-          const blockIndex = typedTool.api.blocks.getBlockIndex(typedTool.block.id);
+          const blockIndex = typedTool.api.blocks.getBlockIndex(
+            typedTool.block.id,
+          );
 
           if (blockIndex === -1) {
             return;
@@ -177,7 +181,12 @@ export const EDITOR_TOOLS: EditorConfig["tools"] = {
           );
 
           try {
-            const snapshot = await uploadBytes(storageRef, file);
+            const contentType = resolveUploadContentType(file);
+            const snapshot = await uploadBytes(
+              storageRef,
+              file,
+              contentType ? { contentType } : undefined,
+            );
             const downloadURL = await getDownloadURL(snapshot.ref);
 
             return {
@@ -445,7 +454,10 @@ const Editor = ({
       />
 
       <div className="mb-4 rounded-sm border p-3">
-        <label className="mb-2 block text-sm font-medium" htmlFor="pasted-editor-json">
+        <label
+          className="mb-2 block text-sm font-medium"
+          htmlFor="pasted-editor-json"
+        >
           Paste raw Editor JSON
         </label>
         <textarea
@@ -457,10 +469,7 @@ const Editor = ({
         />
         <div className="mt-2 flex justify-end">
           <button
-            className={cn(
-              buttonVariants({ variant: "outline" }),
-              "rounded-sm",
-            )}
+            className={cn(buttonVariants({ variant: "outline" }), "rounded-sm")}
             onClick={handleImportPastedJson}
             type="button"
           >

--- a/src/components/article-creator/FetchArticleFunctions.tsx
+++ b/src/components/article-creator/FetchArticleFunctions.tsx
@@ -6,6 +6,7 @@ import type { QuestionFormat } from "@/types/questions";
 import { type OutputData } from "@editorjs/editorjs";
 import { getStorage, ref, uploadBytes, getDownloadURL } from "firebase/storage";
 import { getFileFromIndexedDB } from "./custom_questions/RenderAdvancedTextbox";
+import { resolveUploadContentType } from "@/lib/utils";
 
 export interface ImageData {
   caption: string;
@@ -67,7 +68,12 @@ export const processQuestions = async (
   await Promise.all(
     Array.from(fileKeyToFile.entries()).map(async ([fileKey, file]) => {
       const storageRef = ref(storage, fileKey);
-      const snapshot = await uploadBytes(storageRef, file);
+      const contentType = resolveUploadContentType(file);
+      const snapshot = await uploadBytes(
+        storageRef,
+        file,
+        contentType ? { contentType } : undefined,
+      );
       const downloadURL = await getDownloadURL(snapshot.ref);
       fileKeyToDownloadURL.set(fileKey, downloadURL);
     }),

--- a/src/components/article-creator/Renderer.tsx
+++ b/src/components/article-creator/Renderer.tsx
@@ -210,9 +210,17 @@ const customParsers: Record<
   },
 
   image: (data, _config) => {
+    // SVGs (viewBox only) collapse or render at the 300x150 replaced-element
+    // default unless given a definite width, so tag them for the .img-svg rule.
+    const storageRefPath = data.file?.storageRefFullPath;
+    const storagePath =
+      typeof storageRefPath === "string" ? storageRefPath : "";
+    const isSvg =
+      storagePath.toLowerCase().endsWith(".svg") ||
+      (typeof data.url === "string" && data.url.toLowerCase().includes(".svg"));
     const imageConditions = `${data.stretched ? "img-fullwidth" : ""} ${
       data.withBorder ? "img-border" : ""
-    } ${data.withBackground ? "img-bg" : ""} ${data.centerImage ? "img-center" : ""}`;
+    } ${data.withBackground ? "img-bg" : ""} ${data.centerImage ? "img-center" : ""} ${isSvg ? "img-svg" : ""}`;
     const imgClass = _config.image.imgClass ?? "";
     let imageSrc;
 

--- a/src/components/article-creator/custom_questions/AdvancedTextbox.tsx
+++ b/src/components/article-creator/custom_questions/AdvancedTextbox.tsx
@@ -5,14 +5,18 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 import React, { useRef, useState, useEffect } from "react";
 import { Textarea } from "@/components/ui/textarea";
-import type {
-  QuestionFile,
-  QuestionFormat,
-} from "@/types/questions";
+import type { QuestionFile, QuestionFormat } from "@/types/questions";
 import { Paperclip, Trash, ChevronLeft, ChevronRight } from "lucide-react";
-import { deleteObject, getStorage, ref, uploadBytes, getDownloadURL } from "firebase/storage";
+import {
+  deleteObject,
+  getStorage,
+  ref,
+  uploadBytes,
+  getDownloadURL,
+} from "firebase/storage";
 import { getUser } from "@/components/hooks/users";
 import { getFileFromIndexedDB } from "./RenderAdvancedTextbox";
+import { isSvgFileName, resolveUploadContentType } from "@/lib/utils";
 
 interface Props {
   questions: QuestionFormat[];
@@ -139,15 +143,17 @@ const ThumbnailPreview: React.FC<{ file: QuestionFile }> = ({ file }) => {
       <img
         src={src}
         alt="Thumbnail preview"
-        className="h-20 w-20 rounded object-cover border border-gray-200"
+        className="h-20 w-20 rounded border border-gray-200 object-cover"
       />
     );
   }
 
   return (
-    <div className="flex h-20 w-20 flex-col items-center justify-center rounded bg-blue-50 border border-blue-200 text-blue-500">
+    <div className="flex h-20 w-20 flex-col items-center justify-center rounded border border-blue-200 bg-blue-50 text-blue-500">
       <Paperclip size={20} />
-      <span className="mt-1 text-[9px] truncate max-w-[70px] px-1">{file.name}</span>
+      <span className="mt-1 max-w-[70px] truncate px-1 text-[9px]">
+        {file.name}
+      </span>
     </div>
   );
 };
@@ -165,30 +171,33 @@ export default function AdvancedTextbox({
   const [currentText, setCurrentText] = useState<string>("");
   const [uploadedFiles, setUploadedFiles] = useState<QuestionFile[]>([]);
   const [uploadStatuses, setUploadStatuses] = useState<
-    Record<string, { status: "uploading" | "success" | "error"; error?: string }>
+    Record<
+      string,
+      { status: "uploading" | "success" | "error"; error?: string }
+    >
   >({});
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Sync state when loaded
-    useEffect(() => {
+  useEffect(() => {
     const nextText =
       origin === "option" && oIndex !== undefined
-        ? questionInstance!.options[oIndex]?.value?.value ?? ""
+        ? (questionInstance!.options[oIndex]?.value?.value ?? "")
         : origin === "question" ||
             origin === "explanation" ||
             origin === "content"
-          ? questionInstance![origin]?.value ?? ""
+          ? (questionInstance![origin]?.value ?? "")
           : "";
 
     const nextFiles =
       origin === "option" && oIndex !== undefined
-        ? questionInstance!.options[oIndex]?.value?.files ?? []
+        ? (questionInstance!.options[oIndex]?.value?.files ?? [])
         : origin === "question" ||
             origin === "explanation" ||
             origin === "content"
-          ? questionInstance![origin]?.files ?? []
+          ? (questionInstance![origin]?.files ?? [])
           : [];
 
     if (currentText !== nextText) {
@@ -225,18 +234,21 @@ export default function AdvancedTextbox({
 
       const lastNewLineIndex = textBeforeCursor.lastIndexOf("\n");
       const currentLine = textBeforeCursor.substring(lastNewLineIndex + 1);
-      
+
       const match = currentLine.match(/^\s*/);
       const leadingWhitespace = match ? match[0] : "";
 
       if (leadingWhitespace) {
         e.preventDefault();
-        const newText = textBeforeCursor + "\n" + leadingWhitespace + textAfterCursor;
+        const newText =
+          textBeforeCursor + "\n" + leadingWhitespace + textAfterCursor;
         updateQuestionText(newText);
 
         setTimeout(() => {
           if (textareaRef.current) {
-            textareaRef.current.selectionStart = textareaRef.current.selectionEnd = cursorPosition + 1 + leadingWhitespace.length;
+            textareaRef.current.selectionStart =
+              textareaRef.current.selectionEnd =
+                cursorPosition + 1 + leadingWhitespace.length;
           }
         }, 0);
       }
@@ -254,18 +266,20 @@ export default function AdvancedTextbox({
 
         if (currentLine.length > 0 && /^\s+$/.test(currentLine)) {
           e.preventDefault();
-          
+
           const spacesToDelete = currentLine.length % 2 !== 0 ? 1 : 2;
 
-          const newText = 
-            currentText.substring(0, cursorPosition - spacesToDelete) + 
+          const newText =
+            currentText.substring(0, cursorPosition - spacesToDelete) +
             currentText.substring(cursorPosition);
-            
+
           updateQuestionText(newText);
 
           setTimeout(() => {
             if (textareaRef.current) {
-              textareaRef.current.selectionStart = textareaRef.current.selectionEnd = cursorPosition - spacesToDelete;
+              textareaRef.current.selectionStart =
+                textareaRef.current.selectionEnd =
+                  cursorPosition - spacesToDelete;
             }
           }, 0);
         }
@@ -283,14 +297,14 @@ export default function AdvancedTextbox({
       const end = textarea.selectionEnd;
       const indent = "  ";
       const newText =
-      currentText.substring(0, start) + indent + currentText.substring(end);
-      
+        currentText.substring(0, start) + indent + currentText.substring(end);
+
       updateQuestionText(newText);
 
       setTimeout(() => {
         if (textareaRef.current) {
-          textareaRef.current.selectionStart = textareaRef.current.selectionEnd =
-            start + indent.length;
+          textareaRef.current.selectionStart =
+            textareaRef.current.selectionEnd = start + indent.length;
         }
       }, 0);
     }
@@ -301,7 +315,11 @@ export default function AdvancedTextbox({
     const updatedQuestions = [...questions];
     const updatedQuestion = { ...questionInstance! };
 
-    if (origin === "question" || origin === "explanation" || origin === "content") {
+    if (
+      origin === "question" ||
+      origin === "explanation" ||
+      origin === "content"
+    ) {
       updatedQuestion[origin] = {
         ...updatedQuestion[origin],
         files: newFiles,
@@ -381,7 +399,12 @@ export default function AdvancedTextbox({
     try {
       const storage = getStorage();
       const storageRef = ref(storage, fileKey);
-      const snapshot = await uploadBytes(storageRef, file);
+      const contentType = resolveUploadContentType(file);
+      const snapshot = await uploadBytes(
+        storageRef,
+        file,
+        contentType ? { contentType } : undefined,
+      );
       const downloadURL = await getDownloadURL(snapshot.ref);
 
       setUploadStatuses((prev) => ({
@@ -403,18 +426,19 @@ export default function AdvancedTextbox({
         ...prev,
         [fileKey]: {
           status: "error",
-        error: err instanceof Error ? err.message : "Upload failed",
-      },
+          error: err instanceof Error ? err.message : "Upload failed",
+        },
       }));
     }
   };
-
 
   const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const fileList = e.target.files ?? [];
     let files = Array.from(fileList).filter(
       (file) =>
-        file.type.startsWith("image/") || file.type.startsWith("audio/"),
+        file.type.startsWith("image/") ||
+        file.type.startsWith("audio/") ||
+        isSvgFileName(file.name),
     );
 
     const validFiles = files.filter((file) => file.size <= 5 * 1024 * 1024);
@@ -434,10 +458,15 @@ export default function AdvancedTextbox({
     const filesToUpload: { key: string; file: File }[] = [];
 
     files.forEach((file) => {
-      // Create a unique key that works cleanly in storage
-      const sanitizedType = file.type.replace(/\//g, "-");
+      // Resolve the MIME type (some SVGs report an empty file.type) and build a
+      // storage-safe key. Stripping non-alphanumerics also removes the "+" in
+      // image/svg+xml, while keeping the leading "image-" prefix the renderer
+      // uses to treat the file as an image.
+      const mimeType =
+        file.type || (isSvgFileName(file.name) ? "image/svg+xml" : "");
+      const sanitizedType = mimeType.replace(/[^a-z0-9]+/gi, "-");
       const fileKey = `${sanitizedType}-${Date.now()}-${file.name}`;
-      
+
       storeFileInIndexedDB(fileKey, file);
 
       newFiles.push({
@@ -506,7 +535,9 @@ export default function AdvancedTextbox({
       if (stored?.file) {
         void uploadSingleFile(fileKey, stored.file);
       } else {
-        alert(`Could not find local file data for "${fileName}". Please remove and re-upload.`);
+        alert(
+          `Could not find local file data for "${fileName}". Please remove and re-upload.`,
+        );
       }
     } catch (err) {
       console.error("Retry load from IndexedDB failed:", err);
@@ -516,7 +547,7 @@ export default function AdvancedTextbox({
 
   const updateFileAlt = (fileKey: string, newAlt: string) => {
     const updated = uploadedFiles.map((f) =>
-      f.key === fileKey ? { ...f, alt: newAlt } : f
+      f.key === fileKey ? { ...f, alt: newAlt } : f,
     );
     setUploadedFiles(updated);
     updateQuestionsWithFiles(updated);
@@ -545,13 +576,18 @@ export default function AdvancedTextbox({
     const end = textarea.selectionEnd;
 
     const newText =
-      currentText.substring(0, start) + placeholderText + currentText.substring(end);
-    
+      currentText.substring(0, start) +
+      placeholderText +
+      currentText.substring(end);
+
     updateQuestionText(newText);
 
     setTimeout(() => {
       textarea.focus();
-      textarea.setSelectionRange(start + placeholderText.length, start + placeholderText.length);
+      textarea.setSelectionRange(
+        start + placeholderText.length,
+        start + placeholderText.length,
+      );
     }, 0);
   };
 
@@ -600,7 +636,10 @@ export default function AdvancedTextbox({
                   </div>
 
                   <div className="min-w-0 flex-1">
-                    <div className="truncate text-xs font-semibold text-gray-800" title={file.name}>
+                    <div
+                      className="truncate text-xs font-semibold text-gray-800"
+                      title={file.name}
+                    >
                       {file.name}
                     </div>
 
@@ -620,7 +659,7 @@ export default function AdvancedTextbox({
                     )}
 
                     {statusInfo.status === "success" && (
-                      <span className="mt-1 inline-flex items-center rounded bg-green-50 px-1.5 py-0.5 text-[9px] font-medium text-green-700 border border-green-200">
+                      <span className="mt-1 inline-flex items-center rounded border border-green-200 bg-green-50 px-1.5 py-0.5 text-[9px] font-medium text-green-700">
                         Uploaded
                       </span>
                     )}
@@ -629,7 +668,7 @@ export default function AdvancedTextbox({
                   <button
                     type="button"
                     onClick={() => handleDeleteFile(file.key)}
-                    className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-red-500 transition-colors"
+                    className="rounded p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-red-500"
                     title="Remove file"
                   >
                     <Trash size={14} />
@@ -640,7 +679,7 @@ export default function AdvancedTextbox({
                   <div className="flex items-center gap-1.5">
                     <label
                       htmlFor={`alt-${file.key}`}
-                      className="text-[9px] font-bold text-gray-500 uppercase tracking-wider shrink-0"
+                      className="shrink-0 text-[9px] font-bold uppercase tracking-wider text-gray-500"
                     >
                       Alt:
                     </label>
@@ -650,7 +689,7 @@ export default function AdvancedTextbox({
                       placeholder="Alt text (e.g. Graph of sales)"
                       value={file.alt ?? ""}
                       onChange={(e) => updateFileAlt(file.key, e.target.value)}
-                      className="flex h-7 w-full rounded border border-gray-200 bg-background px-2 py-1 text-xs focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-300 placeholder:text-gray-400"
+                      className="flex h-7 w-full rounded border border-gray-200 bg-background px-2 py-1 text-xs placeholder:text-gray-400 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-300"
                     />
                   </div>
 
@@ -660,7 +699,7 @@ export default function AdvancedTextbox({
                         type="button"
                         disabled={index === 0}
                         onClick={() => moveFile(index, "left")}
-                        className="rounded border border-gray-200 bg-gray-50 p-1 text-gray-600 hover:bg-gray-100 disabled:opacity-40 disabled:hover:bg-gray-50 transition-colors"
+                        className="rounded border border-gray-200 bg-gray-50 p-1 text-gray-600 transition-colors hover:bg-gray-100 disabled:opacity-40 disabled:hover:bg-gray-50"
                         title="Move left/up"
                       >
                         <ChevronLeft size={12} />
@@ -669,7 +708,7 @@ export default function AdvancedTextbox({
                         type="button"
                         disabled={index === uploadedFiles.length - 1}
                         onClick={() => moveFile(index, "right")}
-                        className="rounded border border-gray-200 bg-gray-50 p-1 text-gray-600 hover:bg-gray-100 disabled:opacity-40 disabled:hover:bg-gray-50 transition-colors"
+                        className="rounded border border-gray-200 bg-gray-50 p-1 text-gray-600 transition-colors hover:bg-gray-100 disabled:opacity-40 disabled:hover:bg-gray-50"
                         title="Move right/down"
                       >
                         <ChevronRight size={12} />
@@ -679,7 +718,7 @@ export default function AdvancedTextbox({
                     <button
                       type="button"
                       onClick={() => insertPlaceholder(file, index)}
-                      className="rounded border border-blue-200 bg-blue-50 px-2 py-0.5 text-[10px] font-medium text-blue-700 hover:bg-blue-100 transition-colors"
+                      className="rounded border border-blue-200 bg-blue-50 px-2 py-0.5 text-[10px] font-medium text-blue-700 transition-colors hover:bg-blue-100"
                       title="Insert inline placeholder tag"
                     >
                       Insert Inline
@@ -695,7 +734,7 @@ export default function AdvancedTextbox({
       <div className="mt-2 flex justify-end">
         <button
           type="button"
-          className="flex items-center gap-1 rounded-md border border-blue-500 bg-blue-50 px-3 py-1.5 text-xs font-semibold text-blue-600 hover:bg-blue-100 hover:text-blue-700 transition-all shadow-sm"
+          className="flex items-center gap-1 rounded-md border border-blue-500 bg-blue-50 px-3 py-1.5 text-xs font-semibold text-blue-600 shadow-sm transition-all hover:bg-blue-100 hover:text-blue-700"
           onClick={handleUploadClick}
         >
           <Paperclip size={14} /> Add file

--- a/src/components/article-creator/custom_questions/RenderAdvancedTextbox.tsx
+++ b/src/components/article-creator/custom_questions/RenderAdvancedTextbox.tsx
@@ -4,7 +4,7 @@ import type { QuestionFile, QuestionInput } from "@/types/questions";
 import "../../../styles/katexStyling.css";
 import { decodeEntities, katexMacros } from "../Renderer";
 
-import { cn } from "@/lib/utils";
+import { cn, isSvgFileName } from "@/lib/utils";
 
 interface Props {
   content: QuestionInput;
@@ -107,13 +107,22 @@ const FileRenderer: React.FC<{ file: QuestionFile }> = ({ file }) => {
   if (!objectUrl) return null;
 
   if (isImageFileKey(file.key)) {
+    // SVGs frequently omit intrinsic dimensions (viewBox only), which makes them
+    // collapse or overflow under width/height auto. Give them a definite,
+    // responsive width instead.
+    const isSvg = isSvgFileName(file.name) || file.key.startsWith("image-svg");
     return (
-      <div className="my-2 w-full flex justify-center">
+      <div className="my-2 flex w-full justify-center">
         <img
           src={objectUrl}
           alt={file.alt ?? "Uploaded image"}
           loading="lazy"
-          className="h-auto max-h-[450px] w-auto max-w-full rounded-md object-contain shadow-sm transition-shadow duration-200 hover:shadow-md"
+          className={cn(
+            "rounded-md object-contain shadow-sm transition-shadow duration-200 hover:shadow-md",
+            isSvg
+              ? "h-auto w-full max-w-[450px]"
+              : "h-auto max-h-[450px] w-auto max-w-full",
+          )}
         />
       </div>
     );
@@ -158,7 +167,7 @@ export function RenderContent({ content, origin }: Props) {
     const byName = sortedFiles.find(
       (f) =>
         f.name.toLowerCase() === trimmed.toLowerCase() ||
-        f.name.split(".")[0]?.toLowerCase() === trimmed.toLowerCase()
+        f.name.split(".")[0]?.toLowerCase() === trimmed.toLowerCase(),
     );
     if (byName) return byName;
     return null;
@@ -172,8 +181,11 @@ export function RenderContent({ content, origin }: Props) {
         return (
           <pre
             key={`code-${tokenIndex}`}
-            className="my-2 whitespace-pre-wrap overflow-x-auto rounded p-2 font-mono text-sm leading-relaxed text-black max-w-full"
-            style={{ fontFamily: "'Consolas', monospace", backgroundColor: "#f0f0f0" }}
+            className="my-2 max-w-full overflow-x-auto whitespace-pre-wrap rounded p-2 font-mono text-sm leading-relaxed text-black"
+            style={{
+              fontFamily: "'Consolas', monospace",
+              backgroundColor: "#f0f0f0",
+            }}
           >
             <code>{codeContent}</code>
           </pre>
@@ -196,7 +208,10 @@ export function RenderContent({ content, origin }: Props) {
         if (matchedFile) {
           renderedInlineKeys.add(matchedFile.key);
           return (
-            <div key={`inline-img-${tokenIndex}`} className="my-4 block text-center">
+            <div
+              key={`inline-img-${tokenIndex}`}
+              className="my-4 block text-center"
+            >
               <FileRenderer file={matchedFile} />
               {matchedFile.alt && (
                 <span className="mt-1 block text-center text-xs italic text-gray-500">
@@ -211,9 +226,15 @@ export function RenderContent({ content, origin }: Props) {
     });
 
   // Filter out files that were already rendered inline
-  const remainingFiles = sortedFiles.filter((file) => !renderedInlineKeys.has(file.key));
-  const remainingImages = remainingFiles.filter((file) => isImageFileKey(file.key));
-  const remainingAudio = remainingFiles.filter((file) => isAudioFileKey(file.key));
+  const remainingFiles = sortedFiles.filter(
+    (file) => !renderedInlineKeys.has(file.key),
+  );
+  const remainingImages = remainingFiles.filter((file) =>
+    isImageFileKey(file.key),
+  );
+  const remainingAudio = remainingFiles.filter((file) =>
+    isAudioFileKey(file.key),
+  );
 
   return (
     <div className="custom-katex my-2 whitespace-pre-wrap">
@@ -229,15 +250,17 @@ export function RenderContent({ content, origin }: Props) {
       {remainingImages.length > 0 && (
         <div className="mt-4">
           {origin === "question" && remainingImages.length >= 2 ? (
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 w-full">
+            <div className="grid w-full grid-cols-1 gap-4 sm:grid-cols-2">
               {remainingImages.map((file, idx) => {
-                const isThirdOfThree = remainingImages.length === 3 && idx === 2;
+                const isThirdOfThree =
+                  remainingImages.length === 3 && idx === 2;
                 return (
                   <div
                     key={file.key}
                     className={cn(
-                      "flex flex-col items-center justify-center p-2 rounded-lg border border-gray-200 bg-gray-50/40 shadow-sm",
-                      isThirdOfThree && "sm:col-span-2 sm:max-w-2xl sm:mx-auto w-full"
+                      "flex flex-col items-center justify-center rounded-lg border border-gray-200 bg-gray-50/40 p-2 shadow-sm",
+                      isThirdOfThree &&
+                        "w-full sm:col-span-2 sm:mx-auto sm:max-w-2xl",
                     )}
                   >
                     <FileRenderer file={file} />

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -11,3 +11,20 @@ export function formatSlug(slug: string) {
     .replace(/[^a-z1-9 ]+/g, "")
     .replace(/\s/g, "-");
 }
+
+/**
+ * True when a file (by MIME type or name) is an SVG. Some browsers report an
+ * empty `type` for SVGs, so the filename extension is checked as a fallback.
+ */
+export function isSvgFileName(name?: string | null): boolean {
+  return name?.toLowerCase().endsWith(".svg") ?? false;
+}
+
+/**
+ * Content type to attach when uploading to Firebase Storage. Returns the file's
+ * own MIME type, falling back to image/svg+xml for SVGs that report an empty
+ * type so they are served (and rendered) as images rather than octet-streams.
+ */
+export function resolveUploadContentType(file: File): string | undefined {
+  return file.type || (isSvgFileName(file.name) ? "image/svg+xml" : undefined);
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -89,3 +89,10 @@
 .img.img-center {
   @apply mx-auto;
 }
+
+/* SVGs often ship without intrinsic width/height (viewBox only) and would
+   otherwise render at the 300x150 replaced-element default; give them a
+   definite, responsive width. */
+.img.img-svg {
+  @apply h-auto w-full max-w-[480px];
+}


### PR DESCRIPTION
# Description
 Adds SVG support to the existing media upload across all three content surfaces (articles, MCQs, and FRQs) resolving #271. Rather than building a separate SVG feature, this extends the current image-upload paths (the issue's preferred option), since SVGs are just another image type and a parallel path would duplicate upload/render/storage logic.

# Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

A summary of the change, anything else that will help review this PR

# Demo
You can upload SVGs now

# How Has This Been Tested? How can the reviewer test it?
 Manual (recommended for the reviewer, signed in as admin/member):
  1. **Article:** open the article editor, insert an Image block, upload an `.svg`, save, then open the chapter as a student and confirm it renders at a reasonable size.
  2. **MCQ:** add an SVG to a question stem and to an answer option; save; view in the test renderer.
  3. **FRQ:** add an SVG to the question; save; view in the test renderer.
  4. Test **both** a fixed-dimension SVG and a **viewBox-only** SVG (the latter is the one most likely to look wrong without this change).
  5. Delete a question SVG and confirm it's removed cleanly (validates the `+`-free storage key round-trips through fetch/delete).

# Checklist

- [x] I have performed a self-review of my own code
