### PR TITLE
Add FRQ testing page skeleton

### DIFF
--- a/src/app/subject/[slug]/(no-sidebar)/[unit]/frq/[id]/page.tsx
+++ b/src/app/subject/[slug]/(no-sidebar)/[unit]/frq/[id]/page.tsx
@@ -9,7 +9,7 @@ import { useEffect, useState } from "react";
 const Page = () => {
   const pathname = usePathname();
 
-  const basePath = pathname.split("/").slice(-4).join("_");
+  const basePath = pathname.split("/").filter(Boolean).slice(-4).join("_");
 
   const subject = basePath.split("_")[0]!;
   const unitId = basePath.split("_")[1]?.split("-").at(-1);

--- a/src/app/subject/[slug]/(no-sidebar)/[unit]/frq/[id]/page.tsx
+++ b/src/app/subject/[slug]/(no-sidebar)/[unit]/frq/[id]/page.tsx
@@ -21,6 +21,10 @@ const Page = () => {
 
   useEffect(() => {
     const fetchFRQ = async () => {
+      setLoading(true);
+      setError(null);
+      setFrq(null);
+
       try {
         const docRef = doc(
           db,

--- a/src/app/subject/[slug]/(no-sidebar)/[unit]/frq/[id]/page.tsx
+++ b/src/app/subject/[slug]/(no-sidebar)/[unit]/frq/[id]/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import FRQTestRenderer from "@/components/frq/testRenderer";
+import usePathname from "@/components/client/pathname";
+import { db } from "@/lib/firebase";
+import { doc, getDoc } from "firebase/firestore";
+import { useEffect, useState } from "react";
+
+const Page = () => {
+  const pathname = usePathname();
+
+  const basePath = pathname.split("/").slice(-4).join("_");
+
+  const subject = basePath.split("_")[0]!;
+  const unitId = basePath.split("_")[1]?.split("-").at(-1);
+  const frqId = basePath.split("_")[3]!;
+
+  const [frq, setFrq] = useState<Record<string, unknown> | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchFRQ = async () => {
+      try {
+        const docRef = doc(
+          db,
+          "subjects",
+          subject,
+          "units",
+          unitId!,
+          "frqs",
+          frqId,
+        );
+
+        const docSnap = await getDoc(docRef);
+
+        if (docSnap.exists()) {
+          setFrq({
+            id: docSnap.id,
+            ...docSnap.data(),
+          });
+        } else {
+          setFrq(null);
+        }
+      } catch (error: unknown) {
+        console.error("Error fetching FRQ data:", error);
+        setError("Error fetching FRQ data.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchFRQ().catch((error) => {
+      console.error("Error fetching FRQ data:", error);
+      setError("Error fetching FRQ data.");
+      setLoading(false);
+    });
+  }, [subject, unitId, frqId]);
+
+  return <FRQTestRenderer frq={frq} loading={loading} error={error} />;
+};
+
+export default Page;

--- a/src/components/frq/testRenderer.tsx
+++ b/src/components/frq/testRenderer.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 type FRQTestRendererProps = {
   frq: Record<string, unknown> | null;
   loading?: boolean;

--- a/src/components/frq/testRenderer.tsx
+++ b/src/components/frq/testRenderer.tsx
@@ -1,0 +1,27 @@
+type FRQTestRendererProps = {
+  frq: Record<string, unknown> | null;
+  loading?: boolean;
+  error?: string | null;
+};
+
+const FRQTestRenderer = ({
+  frq,
+  loading = false,
+  error = null,
+}: FRQTestRendererProps) => {
+  if (loading) {
+    return <p>Loading FRQ test...</p>;
+  }
+
+  if (error) {
+    return <p>Failed to load FRQ test.</p>;
+  }
+
+  if (!frq) {
+    return <p>FRQ test not found.</p>;
+  }
+
+  return <p>FRQ test found successfully.</p>;
+};
+
+export default FRQTestRenderer;


### PR DESCRIPTION
# Description

Created the FRQ testing page skeleton.

Changes:
- Added FRQ data-fetching page wrapper at `src/app/subject/[slug]/(no-sidebar)/[unit]/frq/[id]/page.tsx`
- Added `FRQTestRenderer` at `src/components/frq/testRenderer.tsx`
- Fetches FRQ data from Firebase using the subject, unit, and FRQ ID from the URL
- Shows a plain success message if FRQ data is found
- Shows a plain failure/not found message if FRQ data is not found

## Pull Request Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other

## Demo

No screenshot needed yet because this PR only adds a plain text skeleton.

## How Has This Been Tested?

Ran `npm run lint`.

The new page uses the same pattern as the existing MCQ test page and does not include styling or saving logic yet.

## Checklist

- [x] I have performed a self-review of my own code
