### PR TITLE
Create FRQ grading page skeleton

### DIFF
--- a/src/app/frq-grading/[id]/page.tsx
+++ b/src/app/frq-grading/[id]/page.tsx
@@ -13,7 +13,7 @@ type PageProps = {
 };
 
 const Page = ({ params }: PageProps) => {
-  const [frq, setFrq] = useState<FRQSubmission | null>();
+  const [frq, setFrq] = useState<FRQSubmission | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {

--- a/src/app/frq-grading/[id]/page.tsx
+++ b/src/app/frq-grading/[id]/page.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import FRQGradingRenderer from "@/components/frq/gradingRenderer";
+import { db } from "@/lib/firebase";
+import type { FRQSubmission } from "@/types/frq";
+import { doc, getDoc } from "firebase/firestore";
+import { useEffect, useState } from "react";
+
+type PageProps = {
+  params: {
+    id: string;
+  };
+};
+
+const Page = ({ params }: PageProps) => {
+  const [frq, setFrq] = useState<FRQSubmission | null>();
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchFrq = async () => {
+      try {
+        const docRef = doc(db, "ungraded-frqs", params.id);
+        const docSnap = await getDoc(docRef);
+
+        if (docSnap.exists()) {
+          setFrq({
+            id: docSnap.id,
+            ...(docSnap.data() as FRQSubmission),
+          });
+        } else {
+          setFrq(null);
+        }
+      } catch (error) {
+        console.error("Error fetching FRQ:", error);
+        setFrq(null);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void fetchFrq();
+  }, [params.id]);
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  return <FRQGradingRenderer frq={frq ?? null} />;
+};
+
+export default Page;

--- a/src/app/frq-grading/page.tsx
+++ b/src/app/frq-grading/page.tsx
@@ -12,8 +12,6 @@ const Page = () => {
     const fetchFrqs = async () => {
       const collectionRef = collection(db, "ungraded-frqs");
       const snapshot = await getDocs(collectionRef);
-      console.log("FRQ docs:", snapshot.docs.map((doc) => doc.id));
-
       setFrqIds(snapshot.docs.map((doc) => doc.id));
     };
 

--- a/src/app/frq-grading/page.tsx
+++ b/src/app/frq-grading/page.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import Link from "next/link";
+import { db } from "@/lib/firebase";
+import { collection, getDocs } from "firebase/firestore";
+import { useEffect, useState } from "react";
+
+const Page = () => {
+  const [frqIds, setFrqIds] = useState<string[] | null>(null);
+
+  useEffect(() => {
+    const fetchFrqs = async () => {
+      const collectionRef = collection(db, "ungraded-frqs");
+      const snapshot = await getDocs(collectionRef);
+      console.log("FRQ docs:", snapshot.docs.map((doc) => doc.id));
+
+      setFrqIds(snapshot.docs.map((doc) => doc.id));
+    };
+
+    fetchFrqs().catch((error) => {
+      console.error("Error fetching ungraded FRQs:", error);
+      setFrqIds([]);
+    });
+  }, []);
+
+  if (frqIds === null) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div>
+      <h1>Ungraded FRQs</h1>
+
+      {frqIds.length === 0 ? (
+        <p>No ungraded FRQs found.</p>
+      ) : (
+        <ul>
+          {frqIds.map((id) => (
+            <li key={id}>
+              <Link href={`/frq-grading/${id}`}>{id}</Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default Page;

--- a/src/components/frq/gradingRenderer.tsx
+++ b/src/components/frq/gradingRenderer.tsx
@@ -5,7 +5,6 @@ type FRQGradingRendererProps = {
 };
 
 const FRQGradingRenderer = ({ frq }: FRQGradingRendererProps) => {
-  console.log("Renderer received frq:", frq);
   if (!frq) {
     return <div>FRQ not found.</div>;
   }

--- a/src/components/frq/gradingRenderer.tsx
+++ b/src/components/frq/gradingRenderer.tsx
@@ -1,0 +1,16 @@
+import type { FRQSubmission } from "@/types/frq";
+
+type FRQGradingRendererProps = {
+  frq: FRQSubmission | null;
+};
+
+const FRQGradingRenderer = ({ frq }: FRQGradingRendererProps) => {
+  console.log("Renderer received frq:", frq);
+  if (!frq) {
+    return <div>FRQ not found.</div>;
+  }
+
+  return <div>FRQ found. Grading page loaded successfully.</div>;
+};
+
+export default FRQGradingRenderer;


### PR DESCRIPTION
# Description
Created the initial FRQ grading page skeleton by adding an ungraded FRQ list page, a dynamic FRQ grading page, and a basic FRQGradingRenderer component.

The list page retrieves document IDs from the ungraded-frqs Firestore collection and links each item to its corresponding grading page. The grading page fetches the selected FRQ based on the URL parameter and passes the result to FRQGradingRenderer, which currently displays a simple success or failure message depending on whether the FRQ exists.

# Pull request type
Feature for FRQ Grading
Please check the type of change your PR introduces:

- [ ] Bugfix
- [x ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

A summary of the change, anything else that will help review this PR

# Demo
* /frq-grading displays the list of ungraded FRQ IDs.
* Clicking an FRQ navigates to /frq-grading/[id].
* Existing FRQs display a success message.
* Invalid or missing FRQs display "FRQ not found."


# How Has This Been Tested? How can the reviewer test it?
* Start the Firebase Emulator.
* Add a test document to the ungraded-frqs Firestore collection.
* Run the application locally with npm run dev.
* Change endpoint to /frq-grading.
* Verify the list of FRQ IDs is displayed.
* Click an FRQ ID and verify the grading page displays the success message.
* Navigate to an invalid FRQ ID (for example /frq-grading/does-not-exist) and verify the page displays "FRQ not found."
* Ran npm run build successfully to verify the project builds without errors.


# Checklist
- [ x] I have performed a self-review of my own code
