### PR TITLE
Create FRQ editor page skeleton

### DIFF
--- a/src/app/admin/subject/[slug]/[unit]/frq/[id]/page.tsx
+++ b/src/app/admin/subject/[slug]/[unit]/frq/[id]/page.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import FRQEditorRenderer from "@/components/frq/editorRenderer";
+import { db } from "@/lib/firebase";
+import { doc, getDoc } from "firebase/firestore";
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+
+const Page = () => {
+  const pathname = usePathname() ?? "";
+
+  const instanceId = pathname.split("/").slice(-4).join("_");
+  const subject = instanceId.split("_")[0]!;
+  const unitId = instanceId.split("_")[1]!;
+  const frqId = instanceId.split("_")[3]!;
+
+  const [frqFound, setFrqFound] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const docRef = doc(
+        db,
+        "subjects",
+        subject,
+        "units",
+        unitId,
+        "frqs",
+        frqId,
+      );
+
+      const docSnap = await getDoc(docRef);
+      setFrqFound(docSnap.exists());
+    })().catch((error) => {
+      console.error("Error fetching FRQ:", error);
+      setFrqFound(false);
+    });
+  }, [subject, unitId, frqId]);
+
+  if (frqFound === null) {
+    return <div>Loading...</div>;
+  }
+
+  return <FRQEditorRenderer frqFound={frqFound} />;
+};
+
+export default Page;

--- a/src/app/admin/subject/[slug]/[unit]/frq/[id]/page.tsx
+++ b/src/app/admin/subject/[slug]/[unit]/frq/[id]/page.tsx
@@ -9,14 +9,19 @@ import { useEffect, useState } from "react";
 const Page = () => {
   const pathname = usePathname() ?? "";
 
-  const instanceId = pathname.split("/").slice(-4).join("_");
-  const subject = instanceId.split("_")[0]!;
-  const unitId = instanceId.split("_")[1]!;
-  const frqId = instanceId.split("_")[3]!;
+  const pathParts = pathname.split("/").slice(-4);
+  const subject = pathParts[0] ?? "";
+  const unitId = pathParts[1] ?? "";
+  const frqId = pathParts[3] ?? "";
 
   const [frqFound, setFrqFound] = useState<boolean | null>(null);
 
   useEffect(() => {
+    if (!subject || !unitId || !frqId) {
+      setFrqFound(false);
+      return;
+    }
+
     (async () => {
       const docRef = doc(
         db,

--- a/src/components/frq/editorRenderer.tsx
+++ b/src/components/frq/editorRenderer.tsx
@@ -1,0 +1,17 @@
+interface FRQEditorRendererProps {
+  frqFound: boolean;
+}
+
+const FRQEditorRenderer = ({
+  frqFound,
+}: FRQEditorRendererProps) => {
+  return (
+    <div>
+      {frqFound
+        ? "FRQ loaded successfully."
+        : "Failed to load FRQ."}
+    </div>
+  );
+};
+
+export default FRQEditorRenderer;


### PR DESCRIPTION
﻿## Summary

- Adds the admin FRQ editor page and extracts the subject, unit, and FRQ ID from the URL.
- Fetches the FRQ from the required nested Firestore path.
- Adds a plain-text renderer that displays different messages when the FRQ is found or missing.

## Testing

- `npm run lint` — passed with existing unrelated warnings.
- `npm run build` — passed.
- Tested both existing and missing FRQ documents using the local Firebase emulator.

Closes #305
