### PR TITLE
Resize SVG stimulus images proportionally, matching PNG/JPG

### DIFF
--- a/src/components/article-creator/custom_questions/RenderAdvancedTextbox.tsx
+++ b/src/components/article-creator/custom_questions/RenderAdvancedTextbox.tsx
@@ -4,7 +4,7 @@ import type { QuestionFile, QuestionInput } from "@/types/questions";
 import "../../../styles/katexStyling.css";
 import { decodeEntities, katexMacros } from "../Renderer";
 
-import { cn, isSvgFileName } from "@/lib/utils";
+import { cn, isSvgFileName, parseSvgIntrinsicSize } from "@/lib/utils";
 
 interface Props {
   content: QuestionInput;
@@ -75,6 +75,10 @@ export function getFileFromIndexedDB(
 
 const FileRenderer: React.FC<{ file: QuestionFile }> = ({ file }) => {
   const [objectUrl, setObjectUrl] = useState<string | null>(null);
+  const [svgSize, setSvgSize] = useState<{
+    width: number;
+    height: number;
+  } | null>(null);
 
   useEffect(() => {
     let url: string | null = null;
@@ -104,13 +108,34 @@ const FileRenderer: React.FC<{ file: QuestionFile }> = ({ file }) => {
     };
   }, [file]);
 
+  const isSvg = isSvgFileName(file.name) || file.key.startsWith("image-svg");
+
+  // SVGs typically only declare a viewBox (no width/height), so <img> has no
+  // intrinsic size to fall back on and can collapse to the browser's 300x150
+  // replaced-element default. Fetch the raw markup and derive the aspect
+  // ratio so SVGs scale the same way PNG/JPG do instead of a fixed width.
+  useEffect(() => {
+    setSvgSize(null);
+    if (!objectUrl || !isSvg) return;
+
+    let cancelled = false;
+    fetch(objectUrl)
+      .then((res) => res.text())
+      .then((markup) => {
+        if (!cancelled) setSvgSize(parseSvgIntrinsicSize(markup));
+      })
+      .catch((error) => {
+        console.error("Error reading SVG dimensions:", error);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [objectUrl, isSvg]);
+
   if (!objectUrl) return null;
 
   if (isImageFileKey(file.key)) {
-    // SVGs frequently omit intrinsic dimensions (viewBox only), which makes them
-    // collapse or overflow under width/height auto. Give them a definite,
-    // responsive width instead.
-    const isSvg = isSvgFileName(file.name) || file.key.startsWith("image-svg");
     return (
       <div className="my-2 flex w-full justify-center">
         <img
@@ -119,10 +144,15 @@ const FileRenderer: React.FC<{ file: QuestionFile }> = ({ file }) => {
           loading="lazy"
           className={cn(
             "rounded-md object-contain shadow-sm transition-shadow duration-200 hover:shadow-md",
-            isSvg
+            isSvg && !svgSize
               ? "h-auto w-full max-w-[450px]"
               : "h-auto max-h-[450px] w-auto max-w-full",
           )}
+          style={
+            isSvg && svgSize
+              ? { aspectRatio: `${svgSize.width} / ${svgSize.height}` }
+              : undefined
+          }
         />
       </div>
     );

--- a/src/components/article-creator/custom_questions/RenderAdvancedTextbox.tsx
+++ b/src/components/article-creator/custom_questions/RenderAdvancedTextbox.tsx
@@ -118,18 +118,24 @@ const FileRenderer: React.FC<{ file: QuestionFile }> = ({ file }) => {
     setSvgSize(null);
     if (!objectUrl || !isSvg) return;
 
-    let cancelled = false;
-    fetch(objectUrl)
-      .then((res) => res.text())
+    const controller = new AbortController();
+
+    fetch(objectUrl, { signal: controller.signal })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.text();
+      })
       .then((markup) => {
-        if (!cancelled) setSvgSize(parseSvgIntrinsicSize(markup));
+        if (!controller.signal.aborted)
+          setSvgSize(parseSvgIntrinsicSize(markup));
       })
       .catch((error) => {
+        if (controller.signal.aborted) return;
         console.error("Error reading SVG dimensions:", error);
       });
 
     return () => {
-      cancelled = true;
+      controller.abort();
     };
   }, [objectUrl, isSvg]);
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -40,9 +40,10 @@ export function resolveUploadContentType(file: File): string | undefined {
 export function parseSvgIntrinsicSize(
   svgMarkup: string,
 ): { width: number; height: number } | null {
-  const viewBoxMatch = /viewBox\s*=\s*["']\s*[-\d.]+\s+[-\d.]+\s+([\d.]+)\s+([\d.]+)\s*["']/i.exec(
-    svgMarkup,
-  );
+  const viewBoxMatch =
+    /viewBox\s*=\s*["']\s*[-\d.]+\s+[-\d.]+\s+([\d.]+)\s+([\d.]+)\s*["']/i.exec(
+      svgMarkup,
+    );
   if (viewBoxMatch?.[1] && viewBoxMatch[2]) {
     const width = parseFloat(viewBoxMatch[1]);
     const height = parseFloat(viewBoxMatch[2]);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -40,10 +40,11 @@ export function resolveUploadContentType(file: File): string | undefined {
 export function parseSvgIntrinsicSize(
   svgMarkup: string,
 ): { width: number; height: number } | null {
-  const viewBoxMatch =
-    /viewBox\s*=\s*["']\s*[-\d.]+\s+[-\d.]+\s+([\d.]+)\s+([\d.]+)\s*["']/i.exec(
-      svgMarkup,
-    );
+  const num = String.raw`[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?`;
+  const viewBoxMatch = new RegExp(
+    String.raw`viewBox\s*=\s*["']\s*${num}(?:[,\s]+)${num}(?:[,\s]+)(${num})(?:[,\s]+)(${num})\s*["']`,
+    "i",
+  ).exec(svgMarkup);
   if (viewBoxMatch?.[1] && viewBoxMatch[2]) {
     const width = parseFloat(viewBoxMatch[1]);
     const height = parseFloat(viewBoxMatch[2]);
@@ -52,12 +53,14 @@ export function parseSvgIntrinsicSize(
 
   // Fall back to explicit width/height attributes (ignoring % values, which
   // give no absolute ratio) if there's no usable viewBox.
-  const widthMatch = /[^-\w]width\s*=\s*["']\s*([\d.]+)(?:px)?\s*["']/i.exec(
-    svgMarkup,
-  );
-  const heightMatch = /[^-\w]height\s*=\s*["']\s*([\d.]+)(?:px)?\s*["']/i.exec(
-    svgMarkup,
-  );
+  const widthMatch =
+    /(?:^|[^\w-])width\s*=\s*["']\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)(?:\s*(?:px|pt|pc|mm|cm|in))?\s*["']/i.exec(
+      svgMarkup,
+    );
+  const heightMatch =
+    /(?:^|[^\w-])height\s*=\s*["']\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)(?:\s*(?:px|pt|pc|mm|cm|in))?\s*["']/i.exec(
+      svgMarkup,
+    );
   if (widthMatch?.[1] && heightMatch?.[1]) {
     const width = parseFloat(widthMatch[1]);
     const height = parseFloat(heightMatch[1]);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -28,3 +28,40 @@ export function isSvgFileName(name?: string | null): boolean {
 export function resolveUploadContentType(file: File): string | undefined {
   return file.type || (isSvgFileName(file.name) ? "image/svg+xml" : undefined);
 }
+
+/**
+ * Extracts an SVG's intrinsic aspect ratio from its markup. Most SVGs only
+ * declare a `viewBox` (no `width`/`height`), so an `<img>` referencing one
+ * has no natural size to fall back on and can collapse to the browser's
+ * 300x150 replaced-element default. Reading the ratio here lets the caller
+ * size the SVG the same way it sizes PNG/JPG (proportional, capped by CSS)
+ * instead of forcing every SVG to an identical fixed width.
+ */
+export function parseSvgIntrinsicSize(
+  svgMarkup: string,
+): { width: number; height: number } | null {
+  const viewBoxMatch = /viewBox\s*=\s*["']\s*[-\d.]+\s+[-\d.]+\s+([\d.]+)\s+([\d.]+)\s*["']/i.exec(
+    svgMarkup,
+  );
+  if (viewBoxMatch?.[1] && viewBoxMatch[2]) {
+    const width = parseFloat(viewBoxMatch[1]);
+    const height = parseFloat(viewBoxMatch[2]);
+    if (width > 0 && height > 0) return { width, height };
+  }
+
+  // Fall back to explicit width/height attributes (ignoring % values, which
+  // give no absolute ratio) if there's no usable viewBox.
+  const widthMatch = /[^-\w]width\s*=\s*["']\s*([\d.]+)(?:px)?\s*["']/i.exec(
+    svgMarkup,
+  );
+  const heightMatch = /[^-\w]height\s*=\s*["']\s*([\d.]+)(?:px)?\s*["']/i.exec(
+    svgMarkup,
+  );
+  if (widthMatch?.[1] && heightMatch?.[1]) {
+    const width = parseFloat(widthMatch[1]);
+    const height = parseFloat(heightMatch[1]);
+    if (width > 0 && height > 0) return { width, height };
+  }
+
+  return null;
+}


### PR DESCRIPTION
SVGs typically only declare a viewBox (no width/height), so <img> has no intrinsic size to fall back on and previously got forced to a fixed w-full max-w-[450px] box regardless of their actual proportions. Now the SVG's own viewBox/width/height is parsed to derive its aspect ratio, so it scales proportionally within the same bounding box PNG/JPG already use, falling back to the old fixed-width behavior only when no intrinsic size can be determined.

Fixes #321

# Description
Fixes #321 — SVG stimulus images (the reference image attached to a question, explanation, option, or content field in the FRQ/MCQ system) were rendering at a fixed size instead of scaling like PNG/JPG.

Root cause: most SVGs only declare a viewBox (no width/height), so an <img> referencing one has no intrinsic size to fall back on — without one, it can collapse to the browser's 300×150 replaced-element default. The existing workaround forced every SVG into an identical w-full max-w-[450px] box, ignoring the image's actual proportions, so a small icon-shaped diagram got stretched wide while a tall diagram got squashed to the same box.

Fix: added parseSvgIntrinsicSize() (src/lib/utils.ts), which reads the SVG's viewBox (falling back to explicit width/height attrs) to derive its aspect ratio. FileRenderer in RenderAdvancedTextbox.tsx now fetches the SVG's markup, computes that ratio, and applies it via an inline aspect-ratio style alongside the same sizing classes already used for PNG/JPG (h-auto max-h-[450px] w-auto max-w-full object-contain). If no intrinsic size can be parsed (SVG has neither viewBox nor width/height), it falls back to the old fixed-width behavior, so nothing regresses.

FileRenderer/RenderContent is the single shared renderer used by the question editor preview, quizRenderer.tsx, testRenderer.tsx, and the student test-taking view (digital-testing/QuestionPanel.tsx), so this one change covers all of them. No QuestionFile schema changes — size is derived from the file itself at render time, so existing stored assessments render unchanged.

# Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

A summary of the change, anything else that will help review this PR

# Demo

# How Has This Been Tested? How can the reviewer test it?
- npx tsc --noEmit — passes
- eslint on the changed files — passes, no new warnings
- Manually verified in an isolated Microsoft Edge instance against two fixture SVGs (viewBox-only, no width/height attrs) at different aspect ratios, confirming each renders proportionally instead of both collapsing to the same fixed box (screenshot above)
- To test manually: attach an SVG with only a viewBox (no width/height) as a question stimulus image, and compare its rendered size/proportions against a PNG of similar intended dimensions in the question editor preview and the student test-taking view — they should now scale consistently
- Reviewer: spot-check an existing assessment that already has an SVG stimulus to confirm no visual regression

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
