### PR TITLE
Add FRQ editor interface and navigation

### DIFF
--- a/src/components/article-creator/custom_questions/RenderAdvancedTextbox.tsx
+++ b/src/components/article-creator/custom_questions/RenderAdvancedTextbox.tsx
@@ -4,7 +4,7 @@ import type { QuestionFile, QuestionInput } from "@/types/questions";
 import "../../../styles/katexStyling.css";
 import { decodeEntities, katexMacros } from "../Renderer";
 
-import { cn, isSvgFileName } from "@/lib/utils";
+import { cn, isSvgFileName, parseSvgIntrinsicSize } from "@/lib/utils";
 
 interface Props {
   content: QuestionInput;
@@ -75,6 +75,10 @@ export function getFileFromIndexedDB(
 
 const FileRenderer: React.FC<{ file: QuestionFile }> = ({ file }) => {
   const [objectUrl, setObjectUrl] = useState<string | null>(null);
+  const [svgSize, setSvgSize] = useState<{
+    width: number;
+    height: number;
+  } | null>(null);
 
   useEffect(() => {
     let url: string | null = null;
@@ -104,13 +108,34 @@ const FileRenderer: React.FC<{ file: QuestionFile }> = ({ file }) => {
     };
   }, [file]);
 
+  const isSvg = isSvgFileName(file.name) || file.key.startsWith("image-svg");
+
+  // SVGs typically only declare a viewBox (no width/height), so <img> has no
+  // intrinsic size to fall back on and can collapse to the browser's 300x150
+  // replaced-element default. Fetch the raw markup and derive the aspect
+  // ratio so SVGs scale the same way PNG/JPG do instead of a fixed width.
+  useEffect(() => {
+    setSvgSize(null);
+    if (!objectUrl || !isSvg) return;
+
+    let cancelled = false;
+    fetch(objectUrl)
+      .then((res) => res.text())
+      .then((markup) => {
+        if (!cancelled) setSvgSize(parseSvgIntrinsicSize(markup));
+      })
+      .catch((error) => {
+        console.error("Error reading SVG dimensions:", error);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [objectUrl, isSvg]);
+
   if (!objectUrl) return null;
 
   if (isImageFileKey(file.key)) {
-    // SVGs frequently omit intrinsic dimensions (viewBox only), which makes them
-    // collapse or overflow under width/height auto. Give them a definite,
-    // responsive width instead.
-    const isSvg = isSvgFileName(file.name) || file.key.startsWith("image-svg");
     return (
       <div className="my-2 flex w-full justify-center">
         <img
@@ -119,10 +144,15 @@ const FileRenderer: React.FC<{ file: QuestionFile }> = ({ file }) => {
           loading="lazy"
           className={cn(
             "rounded-md object-contain shadow-sm transition-shadow duration-200 hover:shadow-md",
-            isSvg
+            isSvg && !svgSize
               ? "h-auto w-full max-w-[450px]"
               : "h-auto max-h-[450px] w-auto max-w-full",
           )}
+          style={
+            isSvg && svgSize
+              ? { aspectRatio: `${svgSize.width} / ${svgSize.height}` }
+              : undefined
+          }
         />
       </div>
     );

--- a/src/components/article-creator/custom_questions/RenderAdvancedTextbox.tsx
+++ b/src/components/article-creator/custom_questions/RenderAdvancedTextbox.tsx
@@ -118,18 +118,24 @@ const FileRenderer: React.FC<{ file: QuestionFile }> = ({ file }) => {
     setSvgSize(null);
     if (!objectUrl || !isSvg) return;
 
-    let cancelled = false;
-    fetch(objectUrl)
-      .then((res) => res.text())
+    const controller = new AbortController();
+
+    fetch(objectUrl, { signal: controller.signal })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.text();
+      })
       .then((markup) => {
-        if (!cancelled) setSvgSize(parseSvgIntrinsicSize(markup));
+        if (!controller.signal.aborted)
+          setSvgSize(parseSvgIntrinsicSize(markup));
       })
       .catch((error) => {
+        if (controller.signal.aborted) return;
         console.error("Error reading SVG dimensions:", error);
       });
 
     return () => {
-      cancelled = true;
+      controller.abort();
     };
   }, [objectUrl, isSvg]);
 

--- a/src/components/frq/editorFooter.tsx
+++ b/src/components/frq/editorFooter.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { ChevronUp, MapPin, Plus, Trash2 } from "lucide-react";
+
+type BatchVisibility = "public" | "private";
+
+interface FRQNavigationItem {
+  id: string;
+  title: string;
+}
+
+interface FRQEditorFooterProps {
+  frqs: FRQNavigationItem[];
+  currentFrqIndex: number;
+  batchName: string;
+  batchVisibility: BatchVisibility;
+  onBatchNameChange: (name: string) => void;
+  onBatchVisibilityChange: (visibility: BatchVisibility) => void;
+  onSelectFrq: (index: number) => void;
+  onPrevious: () => void;
+  onNext: () => void;
+}
+
+const FRQEditorFooter = ({
+  frqs,
+  currentFrqIndex,
+  batchName,
+  batchVisibility,
+  onBatchNameChange,
+  onBatchVisibilityChange,
+  onSelectFrq,
+  onPrevious,
+  onNext,
+}: FRQEditorFooterProps) => {
+  return (
+    <footer className="fixed bottom-0 left-0 z-50 grid w-full grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-4 border-t-2 border-gray-300 bg-background px-4 py-2.5 text-foreground">
+      <div className="flex min-w-0 items-center gap-2">
+        <Input
+          aria-label="FRQ batch name"
+          value={batchName}
+          onChange={(event) => onBatchNameChange(event.target.value)}
+          className="h-9 max-w-48 font-medium"
+        />
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button type="button" variant="outline" className="capitalize">
+              {batchVisibility}
+            </Button>
+          </DropdownMenuTrigger>
+
+          <DropdownMenuContent align="start">
+            <DropdownMenuRadioGroup
+              value={batchVisibility}
+              onValueChange={(value) => {
+                if (value === "public" || value === "private") {
+                  onBatchVisibilityChange(value);
+                }
+              }}
+            >
+              <DropdownMenuRadioItem value="public">
+                Public
+              </DropdownMenuRadioItem>
+
+              <DropdownMenuRadioItem value="private">
+                Private
+              </DropdownMenuRadioItem>
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <div className="flex items-center justify-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          disabled
+          title="Saved FRQs cannot be deleted"
+        >
+          <Trash2 className="mr-2 size-4" />
+          Delete FRQ
+        </Button>
+
+        <Popover>
+          <PopoverTrigger className="flex items-center gap-1 rounded-md bg-black py-1 pl-3 pr-1 text-sm font-bold tabular-nums text-white">
+            FRQ {currentFrqIndex + 1} of {frqs.length}
+            <ChevronUp />
+          </PopoverTrigger>
+
+          <PopoverContent side="top" sideOffset={12} className="w-72">
+            <p className="font-semibold">Navigate to an FRQ</p>
+
+            <p className="mt-1 text-sm text-muted-foreground">
+              Select an FRQ from this batch.
+            </p>
+
+            <div className="mt-6 grid grid-cols-6 gap-4">
+              {frqs.map((frq, index) => {
+                const isCurrent = index === currentFrqIndex;
+
+                return (
+                  <button
+                    key={frq.id}
+                    type="button"
+                    aria-label={`Go to ${frq.title}`}
+                    onClick={() => onSelectFrq(index)}
+                    className={`relative flex size-8 items-center justify-center border-2 font-medium ${
+                      isCurrent
+                        ? "border-transparent bg-[#2a47bb] text-white"
+                        : "border-dotted border-gray-400 text-[#2a47bb] hover:bg-blue-50"
+                    }`}
+                  >
+                    {index + 1}
+
+                    {isCurrent && (
+                      <MapPin className="absolute -top-5 fill-white stroke-black" />
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          </PopoverContent>
+        </Popover>
+
+        <Button type="button" variant="outline">
+          <Plus className="mr-2 size-4" />
+          Create FRQ
+        </Button>
+      </div>
+
+      <div className="justify-self-end">
+        <button
+          type="button"
+          onClick={onPrevious}
+          disabled={currentFrqIndex === 0}
+          className="rounded-full bg-[#294ad1] px-6 py-2 font-bold text-white hover:bg-[#2a47bb] disabled:cursor-not-allowed disabled:bg-gray-300"
+        >
+          Back
+        </button>
+
+        <button
+          type="button"
+          onClick={onNext}
+          disabled={currentFrqIndex === frqs.length - 1}
+          className="ml-3 rounded-full bg-[#294ad1] px-6 py-2 font-bold text-white hover:bg-[#2a47bb] disabled:cursor-not-allowed disabled:bg-gray-300"
+        >
+          Next
+        </button>
+      </div>
+    </footer>
+  );
+};
+
+export default FRQEditorFooter;

--- a/src/components/frq/editorFooter.tsx
+++ b/src/components/frq/editorFooter.tsx
@@ -15,6 +15,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { ChevronUp, MapPin, Plus, Trash2 } from "lucide-react";
+import { useState } from "react";
 
 type BatchVisibility = "public" | "private";
 
@@ -46,6 +47,15 @@ const FRQEditorFooter = ({
   onPrevious,
   onNext,
 }: FRQEditorFooterProps) => {
+  // Controlled so picking an FRQ closes the panel instead of leaving it parked
+  // over the footer, matching frq/FRQFooter.tsx on the other FRQ pages.
+  const [navigationOpen, setNavigationOpen] = useState(false);
+
+  const selectFrq = (index: number) => {
+    onSelectFrq(index);
+    setNavigationOpen(false);
+  };
+
   return (
     <footer className="fixed bottom-0 left-0 z-50 grid w-full grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-4 border-t-2 border-gray-300 bg-background px-4 py-2.5 text-foreground">
       <div className="flex min-w-0 items-center gap-2">
@@ -95,7 +105,7 @@ const FRQEditorFooter = ({
           Delete FRQ
         </Button>
 
-        <Popover>
+        <Popover open={navigationOpen} onOpenChange={setNavigationOpen}>
           <PopoverTrigger className="flex items-center gap-1 rounded-md bg-black py-1 pl-3 pr-1 text-sm font-bold tabular-nums text-white">
             FRQ {currentFrqIndex + 1} of {frqs.length}
             <ChevronUp />
@@ -117,7 +127,7 @@ const FRQEditorFooter = ({
                     key={frq.id}
                     type="button"
                     aria-label={`Go to ${frq.title}`}
-                    onClick={() => onSelectFrq(index)}
+                    onClick={() => selectFrq(index)}
                     className={`relative flex size-8 items-center justify-center border-2 font-medium ${
                       isCurrent
                         ? "border-transparent bg-[#2a47bb] text-white"
@@ -136,7 +146,12 @@ const FRQEditorFooter = ({
           </PopoverContent>
         </Popover>
 
-        <Button type="button" variant="outline">
+        <Button
+          type="button"
+          variant="outline"
+          disabled
+          title="Creating FRQs is not implemented yet"
+        >
           <Plus className="mr-2 size-4" />
           Create FRQ
         </Button>

--- a/src/components/frq/editorRenderer.tsx
+++ b/src/components/frq/editorRenderer.tsx
@@ -1,15 +1,671 @@
+"use client";
+
+import AdvancedTextbox from "@/components/article-creator/custom_questions/AdvancedTextbox";
+import FRQEditorFooter from "@/components/frq/editorFooter";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import type { QuestionFormat, QuestionInput } from "@/types/questions";
+import { Clock3, Eye, Info, Plus, Save, Trash2 } from "lucide-react";
+import { useState } from "react";
+
+type QuestionStatus = "public" | "legacy";
+type InputType = "text" | "equation";
+type BatchVisibility = "public" | "private";
+
+interface GradingCriterion {
+  id: string;
+  description: string;
+  points: number;
+}
+
+interface EditorQuestion {
+  id: string;
+  questionData: QuestionFormat;
+  points: number;
+  status: QuestionStatus;
+  inputType: InputType;
+  criteria: GradingCriterion[];
+}
+
+interface EditorFRQ {
+  id: string;
+  title: string;
+  description: QuestionInput;
+  questions: EditorQuestion[];
+}
+
 interface FRQEditorRendererProps {
   frqFound: boolean;
 }
 
-const FRQEditorRenderer = ({
-  frqFound,
-}: FRQEditorRendererProps) => {
+const createQuestionInput = (value = ""): QuestionInput => ({
+  value,
+  files: [],
+});
+
+const createDescriptionQuestion = (
+  description: QuestionInput,
+): QuestionFormat => ({
+  question: {
+    value: description.value,
+    files: [...description.files],
+  },
+  type: "frq",
+  options: [],
+  answers: [],
+  explanation: createQuestionInput(),
+  content: createQuestionInput(),
+  topic: "",
+});
+
+const createEditorQuestion = (
+  id: string,
+  prompt: string,
+  points: number,
+): EditorQuestion => ({
+  id,
+  points,
+  status: "public",
+  inputType: "text",
+  criteria: [
+    {
+      id: `${id}-criterion-1`,
+      description: "",
+      points,
+    },
+  ],
+  questionData: {
+    question: createQuestionInput(prompt),
+    type: "frq",
+    options: [],
+    answers: [],
+    explanation: createQuestionInput(),
+    content: createQuestionInput(),
+    topic: "",
+  },
+});
+
+const getSubquestionLabel = (frqIndex: number, questionIndex: number) =>
+  `${frqIndex + 1}${String.fromCharCode(97 + questionIndex)}`;
+
+const mockFRQs: EditorFRQ[] = [
+  {
+    id: "frq-1",
+    title: "FRQ 1",
+    description: createQuestionInput(
+      "Read the source material carefully. Then answer all parts of the question using evidence from the source.",
+    ),
+    questions: [
+      createEditorQuestion(
+        "frq-1-a",
+        "Identify one claim made in the source.",
+        1,
+      ),
+      createEditorQuestion(
+        "frq-1-b",
+        "Explain how evidence from the source supports that claim.",
+        2,
+      ),
+      createEditorQuestion(
+        "frq-1-c",
+        "Evaluate one limitation of the source's argument.",
+        2,
+      ),
+    ],
+  },
+  {
+    id: "frq-2",
+    title: "FRQ 2",
+    description: createQuestionInput(
+      "Examine the provided information and respond to each part of the question.",
+    ),
+    questions: [
+      createEditorQuestion(
+        "frq-2-a",
+        "Describe the main process shown in the provided material.",
+        1,
+      ),
+      createEditorQuestion(
+        "frq-2-b",
+        "Explain one relationship between two parts of the process.",
+        2,
+      ),
+      createEditorQuestion(
+        "frq-2-c",
+        "Use evidence from the material to justify your response.",
+        2,
+      ),
+    ],
+  },
+  {
+    id: "frq-3",
+    title: "FRQ 3",
+    description: createQuestionInput(
+      "Use the information provided to develop and support a defensible response.",
+    ),
+    questions: [
+      createEditorQuestion(
+        "frq-3-a",
+        "State a defensible conclusion based on the information provided.",
+        1,
+      ),
+      createEditorQuestion(
+        "frq-3-b",
+        "Support your conclusion with two relevant pieces of evidence.",
+        2,
+      ),
+      createEditorQuestion(
+        "frq-3-c",
+        "Explain how one piece of evidence could be interpreted differently.",
+        2,
+      ),
+    ],
+  },
+];
+
+const FRQEditorRenderer = ({ frqFound }: FRQEditorRendererProps) => {
+  const [frqs, setFrqs] = useState<EditorFRQ[]>(mockFRQs);
+  const [currentFrqIndex, setCurrentFrqIndex] = useState(0);
+  const [batchName, setBatchName] = useState("FRQ Batch");
+  const [batchVisibility, setBatchVisibility] =
+    useState<BatchVisibility>("public");
+  const [timeLimitMinutes, setTimeLimitMinutes] = useState(90);
+
+  const goToPreviousFrq = () => {
+    setCurrentFrqIndex((index) => Math.max(index - 1, 0));
+  };
+
+  const goToNextFrq = () => {
+    setCurrentFrqIndex((index) => Math.min(index + 1, frqs.length - 1));
+  };
+
+  const updateCurrentFrq = (updater: (frq: EditorFRQ) => EditorFRQ) => {
+    setFrqs((currentFrqs) =>
+      currentFrqs.map((frq, index) =>
+        index === currentFrqIndex ? updater(frq) : frq,
+      ),
+    );
+  };
+
+  const updateQuestion = (
+    questionId: string,
+    updater: (question: EditorQuestion) => EditorQuestion,
+  ) => {
+    updateCurrentFrq((frq) => ({
+      ...frq,
+      questions: frq.questions.map((question) =>
+        question.id === questionId ? updater(question) : question,
+      ),
+    }));
+  };
+
+  const addCriterion = (questionId: string) => {
+    updateQuestion(questionId, (question) => ({
+      ...question,
+      criteria: [
+        ...question.criteria,
+        {
+          id: `${questionId}-criterion-${Date.now()}`,
+          description: "",
+          points: 1,
+        },
+      ],
+    }));
+  };
+
+  const updateCriterion = (
+    questionId: string,
+    criterionId: string,
+    changes: Partial<Pick<GradingCriterion, "description" | "points">>,
+  ) => {
+    updateQuestion(questionId, (question) => ({
+      ...question,
+      criteria: question.criteria.map((criterion) =>
+        criterion.id === criterionId ? { ...criterion, ...changes } : criterion,
+      ),
+    }));
+  };
+
+  const deleteCriterion = (questionId: string, criterionId: string) => {
+    updateQuestion(questionId, (question) => ({
+      ...question,
+      criteria: question.criteria.filter(
+        (criterion) => criterion.id !== criterionId,
+      ),
+    }));
+  };
+
+  if (!frqFound) {
+    return <div>Failed to load FRQ.</div>;
+  }
+
+  const currentFrq = frqs[currentFrqIndex];
+
+  if (!currentFrq) {
+    return <div>Failed to load FRQ.</div>;
+  }
+
+  const descriptionQuestions = [
+    createDescriptionQuestion(currentFrq.description),
+  ];
+
+  const questionFormats = currentFrq.questions.map(
+    (question) => question.questionData,
+  );
+
   return (
-    <div>
-      {frqFound
-        ? "FRQ loaded successfully."
-        : "Failed to load FRQ."}
+    <div className="min-h-screen bg-background text-foreground">
+      <header className="fixed inset-x-0 top-0 z-50 grid h-16 grid-cols-3 items-center border-b bg-background px-5 shadow-sm">
+        <div>
+          <Button type="button" variant="outline">
+            <Eye className="mr-2 size-4" />
+            Preview
+          </Button>
+        </div>
+
+        <div className="flex items-center justify-center gap-2">
+          <Clock3 className="size-4 text-muted-foreground" />
+          <label htmlFor="frq-time-limit" className="text-sm font-medium">
+            Time limit
+          </label>
+          <Input
+            id="frq-time-limit"
+            type="number"
+            min={1}
+            value={timeLimitMinutes}
+            onChange={(event) =>
+              setTimeLimitMinutes(Math.max(1, Number(event.target.value) || 1))
+            }
+            className="h-9 w-20"
+          />
+          <span className="text-sm text-muted-foreground">minutes</span>
+        </div>
+
+        <div className="justify-self-end">
+          <Button type="button">
+            <Save className="mr-2 size-4" />
+            Save Changes
+          </Button>
+        </div>
+      </header>
+
+      <main className="fixed inset-x-0 bottom-20 top-16 overflow-hidden bg-muted/20">
+        <div className="grid h-full grid-cols-1 overflow-y-auto lg:grid-cols-2 lg:overflow-hidden">
+          <section className="min-h-0 overflow-y-auto border-b p-6 lg:border-b-0 lg:border-r">
+            <div className="mb-6">
+              <p className="text-sm font-medium text-muted-foreground">
+                FRQ {currentFrqIndex + 1} of {frqs.length}
+              </p>
+
+              <label
+                htmlFor="frq-title"
+                className="mt-4 block text-sm font-medium"
+              >
+                FRQ title
+              </label>
+              <Input
+                id="frq-title"
+                value={currentFrq.title}
+                onChange={(event) =>
+                  updateCurrentFrq((frq) => ({
+                    ...frq,
+                    title: event.target.value,
+                  }))
+                }
+                className="mt-2 max-w-md text-base font-semibold"
+              />
+            </div>
+
+            <div>
+              <h1 className="text-xl font-semibold">FRQ Description</h1>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Add the source material and directions students need for this
+                FRQ.
+              </p>
+
+              <div className="mt-4">
+                <AdvancedTextbox
+                  key={`${currentFrq.id}-description`}
+                  questions={descriptionQuestions}
+                  setQuestions={(updatedQuestions) => {
+                    const updatedDescription = updatedQuestions[0]?.question;
+
+                    if (!updatedDescription) {
+                      return;
+                    }
+
+                    updateCurrentFrq((frq) => ({
+                      ...frq,
+                      description: updatedDescription,
+                    }));
+                  }}
+                  origin="question"
+                  qIndex={0}
+                  placeholder="Enter the FRQ description here."
+                />
+              </div>
+            </div>
+          </section>
+
+          <section className="min-h-0 overflow-y-auto p-6">
+            <div className="mb-5 flex items-center justify-between gap-4">
+              <div>
+                <h2 className="text-xl font-semibold">Questions</h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {currentFrq.questions.length} questions in this FRQ
+                </p>
+              </div>
+
+              <Button type="button">
+                <Plus className="mr-2 size-4" />
+                Add Question
+              </Button>
+            </div>
+
+            <Accordion
+              key={currentFrq.id}
+              type="multiple"
+              defaultValue={currentFrq.questions.map((question) => question.id)}
+              className="space-y-4"
+            >
+              {currentFrq.questions.map((question, questionIndex) => (
+                <AccordionItem
+                  key={question.id}
+                  value={question.id}
+                  className="rounded-lg border bg-background px-4 shadow-sm"
+                >
+                  <AccordionTrigger
+                    variant="secondary"
+                    className="mr-0 py-4 hover:no-underline"
+                  >
+                    <div className="flex flex-1 items-center justify-between pr-3">
+                      <span className="font-semibold">
+                        {getSubquestionLabel(
+                          currentFrqIndex,
+                          questionIndex,
+                        )}
+                      </span>
+                      <span className="text-sm font-normal text-muted-foreground">
+                        {question.points}{" "}
+                        {question.points === 1 ? "point" : "points"}
+                      </span>
+                    </div>
+                  </AccordionTrigger>
+
+                  <AccordionContent
+                    style={{ opacity: 1 }}
+                    className="space-y-5 pb-5 text-foreground"
+                  >
+                    <div>
+                      <label className="text-sm font-medium">
+                        Question prompt
+                      </label>
+                      <div className="mt-2">
+                        <AdvancedTextbox
+                          questions={questionFormats}
+                          setQuestions={(updatedQuestions) => {
+                            updateCurrentFrq((frq) => ({
+                              ...frq,
+                              questions: frq.questions.map(
+                                (frqQuestion, index) => ({
+                                  ...frqQuestion,
+                                  questionData:
+                                    updatedQuestions[index] ??
+                                    frqQuestion.questionData,
+                                }),
+                              ),
+                            }));
+                          }}
+                          origin="question"
+                          qIndex={questionIndex}
+                          placeholder="Enter the question prompt here."
+                        />
+                      </div>
+                    </div>
+
+                    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                      <div>
+                        <label className="text-sm font-medium">Points</label>
+                        <Input
+                          type="number"
+                          min={0}
+                          step={1}
+                          value={question.points}
+                          onChange={(event) =>
+                            updateQuestion(question.id, (currentQuestion) => ({
+                              ...currentQuestion,
+                              points: Math.max(
+                                0,
+                                Number(event.target.value) || 0,
+                              ),
+                            }))
+                          }
+                          className="mt-2"
+                        />
+                      </div>
+
+                      <div>
+                        <label className="text-sm font-medium">
+                          Input type
+                        </label>
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              className="mt-2 w-full justify-between"
+                            >
+                              {question.inputType === "text"
+                                ? "Text"
+                                : "Equation"}
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="start">
+                            <DropdownMenuRadioGroup
+                              value={question.inputType}
+                              onValueChange={(value) => {
+                                if (value !== "text" && value !== "equation") {
+                                  return;
+                                }
+
+                                updateQuestion(
+                                  question.id,
+                                  (currentQuestion) => ({
+                                    ...currentQuestion,
+                                    inputType: value,
+                                  }),
+                                );
+                              }}
+                            >
+                              <DropdownMenuRadioItem value="text">
+                                Text
+                              </DropdownMenuRadioItem>
+                              <DropdownMenuRadioItem value="equation">
+                                Equation
+                              </DropdownMenuRadioItem>
+                            </DropdownMenuRadioGroup>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </div>
+
+                      <div>
+                        <label className="text-sm font-medium">Status</label>
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              className="mt-2 w-full justify-between"
+                            >
+                              {question.status === "public"
+                                ? "Public"
+                                : "Legacy"}
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="start">
+                            <DropdownMenuRadioGroup
+                              value={question.status}
+                              onValueChange={(value) => {
+                                if (value !== "public" && value !== "legacy") {
+                                  return;
+                                }
+
+                                updateQuestion(
+                                  question.id,
+                                  (currentQuestion) => ({
+                                    ...currentQuestion,
+                                    status: value,
+                                  }),
+                                );
+                              }}
+                            >
+                              <DropdownMenuRadioItem value="public">
+                                Public
+                              </DropdownMenuRadioItem>
+                              <DropdownMenuRadioItem value="legacy">
+                                Legacy
+                              </DropdownMenuRadioItem>
+                            </DropdownMenuRadioGroup>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </div>
+                    </div>
+
+                    <div className="flex flex-wrap items-center gap-2 border-t pt-4">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => addCriterion(question.id)}
+                      >
+                        <Plus className="mr-2 size-4" />
+                        Add Criteria
+                      </Button>
+
+                      <Button
+                        type="button"
+                        variant="outline"
+                        title="Question information"
+                        aria-label="Question information"
+                        className="px-3"
+                      >
+                        <Info className="size-4" />
+                      </Button>
+
+                      <Button
+                        type="button"
+                        variant="outline"
+                        disabled
+                        title="Saved questions cannot be deleted"
+                        className="ml-auto text-destructive"
+                      >
+                        <Trash2 className="mr-2 size-4" />
+                        Delete Question
+                      </Button>
+                    </div>
+
+                    <div className="space-y-3">
+                      <h3 className="text-sm font-semibold">
+                        Grading Criteria
+                      </h3>
+
+                      {question.criteria.length === 0 ? (
+                        <p className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+                          No grading criteria have been added.
+                        </p>
+                      ) : (
+                        question.criteria.map((criterion, criterionIndex) => (
+                          <div
+                            key={criterion.id}
+                            className="grid gap-3 rounded-md border bg-muted/20 p-4 md:grid-cols-[minmax(0,1fr)_7rem_auto]"
+                          >
+                            <div>
+                              <label className="text-sm font-medium">
+                                Criterion {criterionIndex + 1}
+                              </label>
+                              <Textarea
+                                value={criterion.description}
+                                onChange={(event) =>
+                                  updateCriterion(question.id, criterion.id, {
+                                    description: event.target.value,
+                                  })
+                                }
+                                placeholder="Describe what earns these points."
+                                className="mt-2 min-h-24"
+                              />
+                            </div>
+
+                            <div>
+                              <label className="text-sm font-medium">
+                                Points
+                              </label>
+                              <Input
+                                type="number"
+                                min={0}
+                                step={1}
+                                value={criterion.points}
+                                onChange={(event) =>
+                                  updateCriterion(question.id, criterion.id, {
+                                    points: Math.max(
+                                      0,
+                                      Number(event.target.value) || 0,
+                                    ),
+                                  })
+                                }
+                                className="mt-2"
+                              />
+                            </div>
+
+                            <Button
+                              type="button"
+                              variant="outline"
+                              onClick={() =>
+                                deleteCriterion(question.id, criterion.id)
+                              }
+                              title="Delete criterion"
+                              aria-label={`Delete criterion ${
+                                criterionIndex + 1
+                              }`}
+                              className="mt-7 size-10 p-0 text-destructive"
+                            >
+                              <Trash2 className="size-4" />
+                            </Button>
+                          </div>
+                        ))
+                      )}
+                    </div>
+                  </AccordionContent>
+                </AccordionItem>
+              ))}
+            </Accordion>
+          </section>
+        </div>
+      </main>
+
+      <FRQEditorFooter
+        frqs={frqs}
+        currentFrqIndex={currentFrqIndex}
+        batchName={batchName}
+        batchVisibility={batchVisibility}
+        onBatchNameChange={setBatchName}
+        onBatchVisibilityChange={setBatchVisibility}
+        onSelectFrq={setCurrentFrqIndex}
+        onPrevious={goToPreviousFrq}
+        onNext={goToNextFrq}
+      />
     </div>
   );
 };

--- a/src/components/frq/editorRenderer.tsx
+++ b/src/components/frq/editorRenderer.tsx
@@ -20,7 +20,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import type { QuestionFormat, QuestionInput } from "@/types/questions";
 import { Clock3, Eye, Info, Plus, Save, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 type QuestionStatus = "public" | "legacy";
 type InputType = "text" | "equation";
@@ -35,7 +35,6 @@ interface GradingCriterion {
 interface EditorQuestion {
   id: string;
   questionData: QuestionFormat;
-  points: number;
   status: QuestionStatus;
   inputType: InputType;
   criteria: GradingCriterion[];
@@ -56,6 +55,28 @@ const createQuestionInput = (value = ""): QuestionInput => ({
   value,
   files: [],
 });
+
+/**
+ * Unique, immutable ID built from the current time plus a short random suffix,
+ * per the FRQ system spec. The random half is what makes it collision-safe:
+ * a timestamp alone repeats when several IDs are minted in the same
+ * millisecond.
+ */
+const makeId = (prefix: string) =>
+  `${prefix}-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 8)}`;
+
+/**
+ * A question's point value is the sum of its grading criteria. Criteria are the
+ * single source of truth so the editor can never disagree with what the grading
+ * page will actually award.
+ */
+const getQuestionPoints = (question: EditorQuestion) =>
+  question.criteria.reduce((total, criterion) => total + criterion.points, 0);
+
+const formatPoints = (points: number) =>
+  `${points} ${points === 1 ? "point" : "points"}`;
 
 const createDescriptionQuestion = (
   description: QuestionInput,
@@ -78,7 +99,6 @@ const createEditorQuestion = (
   points: number,
 ): EditorQuestion => ({
   id,
-  points,
   status: "public",
   inputType: "text",
   criteria: [
@@ -99,8 +119,22 @@ const createEditorQuestion = (
   },
 });
 
-const getSubquestionLabel = (frqIndex: number, questionIndex: number) =>
-  `${frqIndex + 1}${String.fromCharCode(97 + questionIndex)}`;
+/**
+ * AP-style subquestion label: 1a, 1b, 1c. Past 26 questions it rolls over to
+ * two letters (1aa, 1ab) rather than walking off the end of the alphabet into
+ * punctuation, which is what a bare String.fromCharCode(97 + index) would do.
+ */
+const getSubquestionLabel = (frqIndex: number, questionIndex: number) => {
+  let label = "";
+  let remaining = questionIndex;
+
+  do {
+    label = String.fromCharCode(97 + (remaining % 26)) + label;
+    remaining = Math.floor(remaining / 26) - 1;
+  } while (remaining >= 0);
+
+  return `${frqIndex + 1}${label}`;
+};
 
 const mockFRQs: EditorFRQ[] = [
   {
@@ -219,7 +253,7 @@ const FRQEditorRenderer = ({ frqFound }: FRQEditorRendererProps) => {
       criteria: [
         ...question.criteria,
         {
-          id: `${questionId}-criterion-${Date.now()}`,
+          id: makeId("criterion"),
           description: "",
           points: 1,
         },
@@ -249,29 +283,41 @@ const FRQEditorRenderer = ({ frqFound }: FRQEditorRendererProps) => {
     }));
   };
 
-  if (!frqFound) {
-    return <div>Failed to load FRQ.</div>;
-  }
-
   const currentFrq = frqs[currentFrqIndex];
 
-  if (!currentFrq) {
+  // Read through to the fields the memos actually depend on. AdvancedTextbox
+  // treats its `questions[qIndex]` entry as a stable reference, so these must
+  // keep their identity across unrelated re-renders instead of being rebuilt
+  // fresh every time the parent renders. Both memos sit above the early returns
+  // so the hooks stay unconditional.
+  const currentDescription = currentFrq?.description;
+  const currentQuestions = currentFrq?.questions;
+
+  const descriptionQuestions = useMemo(
+    () =>
+      currentDescription ? [createDescriptionQuestion(currentDescription)] : [],
+    [currentDescription],
+  );
+
+  const questionFormats = useMemo(
+    () => currentQuestions?.map((question) => question.questionData) ?? [],
+    [currentQuestions],
+  );
+
+  if (!frqFound || !currentFrq) {
     return <div>Failed to load FRQ.</div>;
   }
-
-  const descriptionQuestions = [
-    createDescriptionQuestion(currentFrq.description),
-  ];
-
-  const questionFormats = currentFrq.questions.map(
-    (question) => question.questionData,
-  );
 
   return (
     <div className="min-h-screen bg-background text-foreground">
       <header className="fixed inset-x-0 top-0 z-50 grid h-16 grid-cols-3 items-center border-b bg-background px-5 shadow-sm">
         <div>
-          <Button type="button" variant="outline">
+          <Button
+            type="button"
+            variant="outline"
+            disabled
+            title="Preview is not implemented yet"
+          >
             <Eye className="mr-2 size-4" />
             Preview
           </Button>
@@ -296,7 +342,11 @@ const FRQEditorRenderer = ({ frqFound }: FRQEditorRendererProps) => {
         </div>
 
         <div className="justify-self-end">
-          <Button type="button">
+          <Button
+            type="button"
+            disabled
+            title="Saving to Firestore is not implemented yet"
+          >
             <Save className="mr-2 size-4" />
             Save Changes
           </Button>
@@ -370,7 +420,11 @@ const FRQEditorRenderer = ({ frqFound }: FRQEditorRendererProps) => {
                 </p>
               </div>
 
-              <Button type="button">
+              <Button
+                type="button"
+                disabled
+                title="Adding questions is not implemented yet"
+              >
                 <Plus className="mr-2 size-4" />
                 Add Question
               </Button>
@@ -393,19 +447,27 @@ const FRQEditorRenderer = ({ frqFound }: FRQEditorRendererProps) => {
                     className="mr-0 py-4 hover:no-underline"
                   >
                     <div className="flex flex-1 items-center justify-between pr-3">
-                      <span className="font-semibold">
-                        {getSubquestionLabel(
-                          currentFrqIndex,
-                          questionIndex,
+                      <span className="flex items-center gap-2">
+                        <span className="font-semibold">
+                          {getSubquestionLabel(currentFrqIndex, questionIndex)}
+                        </span>
+
+                        {question.status === "legacy" && (
+                          <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                            Legacy
+                          </span>
                         )}
                       </span>
                       <span className="text-sm font-normal text-muted-foreground">
-                        {question.points}{" "}
-                        {question.points === 1 ? "point" : "points"}
+                        {formatPoints(getQuestionPoints(question))}
                       </span>
                     </div>
                   </AccordionTrigger>
 
+                  {/* ui/accordion.tsx hardcodes opacity-70 on the content root
+                      and routes className to an inner div, so there is no
+                      class-based override. Without this the editor's inputs all
+                      render washed out. Remove once accordion.tsx exposes it. */}
                   <AccordionContent
                     style={{ opacity: 1 }}
                     className="space-y-5 pb-5 text-foreground"
@@ -417,19 +479,20 @@ const FRQEditorRenderer = ({ frqFound }: FRQEditorRendererProps) => {
                       <div className="mt-2">
                         <AdvancedTextbox
                           questions={questionFormats}
-                          setQuestions={(updatedQuestions) => {
-                            updateCurrentFrq((frq) => ({
-                              ...frq,
-                              questions: frq.questions.map(
-                                (frqQuestion, index) => ({
-                                  ...frqQuestion,
-                                  questionData:
-                                    updatedQuestions[index] ??
-                                    frqQuestion.questionData,
-                                }),
-                              ),
-                            }));
-                          }}
+                          // AdvancedTextbox hands back the whole array, but only
+                          // this question's entry is ours to write. An in-flight
+                          // file upload resolves against the array it captured
+                          // when the upload started, so copying every index back
+                          // would let a slow upload overwrite edits made to the
+                          // sibling questions in the meantime.
+                          setQuestions={(updatedQuestions) =>
+                            updateQuestion(question.id, (currentQuestion) => ({
+                              ...currentQuestion,
+                              questionData:
+                                updatedQuestions[questionIndex] ??
+                                currentQuestion.questionData,
+                            }))
+                          }
                           origin="question"
                           qIndex={questionIndex}
                           placeholder="Enter the question prompt here."
@@ -437,27 +500,10 @@ const FRQEditorRenderer = ({ frqFound }: FRQEditorRendererProps) => {
                       </div>
                     </div>
 
-                    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-                      <div>
-                        <label className="text-sm font-medium">Points</label>
-                        <Input
-                          type="number"
-                          min={0}
-                          step={1}
-                          value={question.points}
-                          onChange={(event) =>
-                            updateQuestion(question.id, (currentQuestion) => ({
-                              ...currentQuestion,
-                              points: Math.max(
-                                0,
-                                Number(event.target.value) || 0,
-                              ),
-                            }))
-                          }
-                          className="mt-2"
-                        />
-                      </div>
-
+                    {/* No question-level points field: the total is derived from
+                        the grading criteria below, which is what the grader
+                        actually awards against. */}
+                    <div className="grid gap-4 sm:grid-cols-2">
                       <div>
                         <label className="text-sm font-medium">
                           Input type
@@ -558,7 +604,8 @@ const FRQEditorRenderer = ({ frqFound }: FRQEditorRendererProps) => {
                       <Button
                         type="button"
                         variant="outline"
-                        title="Question information"
+                        disabled
+                        title="Question information is not implemented yet"
                         aria-label="Question information"
                         className="px-3"
                       >

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -40,9 +40,10 @@ export function resolveUploadContentType(file: File): string | undefined {
 export function parseSvgIntrinsicSize(
   svgMarkup: string,
 ): { width: number; height: number } | null {
-  const viewBoxMatch = /viewBox\s*=\s*["']\s*[-\d.]+\s+[-\d.]+\s+([\d.]+)\s+([\d.]+)\s*["']/i.exec(
-    svgMarkup,
-  );
+  const viewBoxMatch =
+    /viewBox\s*=\s*["']\s*[-\d.]+\s+[-\d.]+\s+([\d.]+)\s+([\d.]+)\s*["']/i.exec(
+      svgMarkup,
+    );
   if (viewBoxMatch?.[1] && viewBoxMatch[2]) {
     const width = parseFloat(viewBoxMatch[1]);
     const height = parseFloat(viewBoxMatch[2]);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -40,10 +40,11 @@ export function resolveUploadContentType(file: File): string | undefined {
 export function parseSvgIntrinsicSize(
   svgMarkup: string,
 ): { width: number; height: number } | null {
-  const viewBoxMatch =
-    /viewBox\s*=\s*["']\s*[-\d.]+\s+[-\d.]+\s+([\d.]+)\s+([\d.]+)\s*["']/i.exec(
-      svgMarkup,
-    );
+  const num = String.raw`[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?`;
+  const viewBoxMatch = new RegExp(
+    String.raw`viewBox\s*=\s*["']\s*${num}(?:[,\s]+)${num}(?:[,\s]+)(${num})(?:[,\s]+)(${num})\s*["']`,
+    "i",
+  ).exec(svgMarkup);
   if (viewBoxMatch?.[1] && viewBoxMatch[2]) {
     const width = parseFloat(viewBoxMatch[1]);
     const height = parseFloat(viewBoxMatch[2]);
@@ -52,12 +53,14 @@ export function parseSvgIntrinsicSize(
 
   // Fall back to explicit width/height attributes (ignoring % values, which
   // give no absolute ratio) if there's no usable viewBox.
-  const widthMatch = /[^-\w]width\s*=\s*["']\s*([\d.]+)(?:px)?\s*["']/i.exec(
-    svgMarkup,
-  );
-  const heightMatch = /[^-\w]height\s*=\s*["']\s*([\d.]+)(?:px)?\s*["']/i.exec(
-    svgMarkup,
-  );
+  const widthMatch =
+    /(?:^|[^\w-])width\s*=\s*["']\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)(?:\s*(?:px|pt|pc|mm|cm|in))?\s*["']/i.exec(
+      svgMarkup,
+    );
+  const heightMatch =
+    /(?:^|[^\w-])height\s*=\s*["']\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)(?:\s*(?:px|pt|pc|mm|cm|in))?\s*["']/i.exec(
+      svgMarkup,
+    );
   if (widthMatch?.[1] && heightMatch?.[1]) {
     const width = parseFloat(widthMatch[1]);
     const height = parseFloat(heightMatch[1]);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -28,3 +28,40 @@ export function isSvgFileName(name?: string | null): boolean {
 export function resolveUploadContentType(file: File): string | undefined {
   return file.type || (isSvgFileName(file.name) ? "image/svg+xml" : undefined);
 }
+
+/**
+ * Extracts an SVG's intrinsic aspect ratio from its markup. Most SVGs only
+ * declare a `viewBox` (no `width`/`height`), so an `<img>` referencing one
+ * has no natural size to fall back on and can collapse to the browser's
+ * 300x150 replaced-element default. Reading the ratio here lets the caller
+ * size the SVG the same way it sizes PNG/JPG (proportional, capped by CSS)
+ * instead of forcing every SVG to an identical fixed width.
+ */
+export function parseSvgIntrinsicSize(
+  svgMarkup: string,
+): { width: number; height: number } | null {
+  const viewBoxMatch = /viewBox\s*=\s*["']\s*[-\d.]+\s+[-\d.]+\s+([\d.]+)\s+([\d.]+)\s*["']/i.exec(
+    svgMarkup,
+  );
+  if (viewBoxMatch?.[1] && viewBoxMatch[2]) {
+    const width = parseFloat(viewBoxMatch[1]);
+    const height = parseFloat(viewBoxMatch[2]);
+    if (width > 0 && height > 0) return { width, height };
+  }
+
+  // Fall back to explicit width/height attributes (ignoring % values, which
+  // give no absolute ratio) if there's no usable viewBox.
+  const widthMatch = /[^-\w]width\s*=\s*["']\s*([\d.]+)(?:px)?\s*["']/i.exec(
+    svgMarkup,
+  );
+  const heightMatch = /[^-\w]height\s*=\s*["']\s*([\d.]+)(?:px)?\s*["']/i.exec(
+    svgMarkup,
+  );
+  if (widthMatch?.[1] && heightMatch?.[1]) {
+    const width = parseFloat(widthMatch[1]);
+    const height = parseFloat(heightMatch[1]);
+    if (width > 0 && height > 0) return { width, height };
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- Builds the FRQ editor interface for descriptions, questions, points, response types, statuses, and grading criteria.
- Adds footer controls for batch information, visibility, FRQ selection, and previous/next navigation.
- Uses AP-style subquestion labels such as 1a, 1b, and 1c.
- Keeps all data in memory for now; Firestore saving is not included yet.

## Testing

- `npx eslint src/components/frq/editorRenderer.tsx src/components/frq/editorFooter.tsx` — passed.
- `npm run build` — passed with existing unrelated warnings.
- Manually tested FRQ navigation and subquestion labels using the local Firebase emulators.