### PR TITLE
Firebase Refactoring for FRQ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,7 @@ src/lib/AddAdminRoles
 
 # firebase emulator
 .firebaserc
-firebase.json
 firebase-debug.log
-firestore.indexes.json
 firestore-debug.log
 storage.rules
 firebase-storage.rules

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,11 @@
+{
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  },
+  "emulators": {
+    "auth": { "port": 9099 },
+    "firestore": { "port": 8080 },
+    "ui": { "enabled": true, "port": 4000 }
+  }
+}

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,28 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "gradableFrqSubmissions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "submittedAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "gradableFrqSubmissions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "studentId", "order": "ASCENDING" },
+        { "fieldPath": "submittedAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "gradedFrqSubmissions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "studentId", "order": "ASCENDING" },
+        { "fieldPath": "gradedAt", "order": "DESCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -94,6 +94,7 @@ service cloud.firestore {
       allow get, list: if isGraderOrAdmin() ||
         (isAuthenticated() && resource.data.studentId == request.auth.uid);
       allow create: if isGraderOrAdmin()
+        && resultId == request.resource.data.sourceSubmissionId
         && request.resource.data.keys().hasOnly(['sourceSubmissionId', 'templateId', 'studentId', 'responses', 'submittedAt', 'score', 'feedback', 'graderId', 'gradedAt'])
         && request.resource.data.sourceSubmissionId is string
         && request.resource.data.templateId is string

--- a/firestore.rules
+++ b/firestore.rules
@@ -85,7 +85,7 @@ service cloud.firestore {
         && request.resource.data.keys().hasOnly(['templateId', 'studentId', 'responses', 'submittedAt'])
         && request.resource.data.templateId is string
         && request.resource.data.studentId == request.auth.uid
-        && request.resource.data.responses is list
+        && request.resource.data.responses is map
         && exists(/databases/$(database)/documents/frqTemplates/$(request.resource.data.templateId));
       allow delete: if isGraderOrAdmin();
     }
@@ -98,7 +98,7 @@ service cloud.firestore {
         && request.resource.data.sourceSubmissionId is string
         && request.resource.data.templateId is string
         && request.resource.data.studentId is string
-        && request.resource.data.responses is list
+        && request.resource.data.responses is map
         && request.resource.data.score is string
         && request.resource.data.feedback is string
         && request.resource.data.graderId == request.auth.uid;

--- a/firestore.rules
+++ b/firestore.rules
@@ -25,9 +25,9 @@ service cloud.firestore {
     }
 
     function isGraderOrAdmin() {
+      let accessLevel = get(/databases/$(database)/documents/users/$(request.auth.uid)).data.access;
       return isAuthenticated() &&
-        (get(/databases/$(database)/documents/users/$(request.auth.uid)).data.access == "admin" ||
-        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.access == "grader");
+        (accessLevel == "admin" || accessLevel == "grader");
     }
 
     // Allow read/write access to users for their own user data

--- a/firestore.rules
+++ b/firestore.rules
@@ -24,6 +24,12 @@ service cloud.firestore {
       return isAuthenticated() && (accessLevel == "admin" || accessLevel == "member" || accessLevel == "grader");
     }
 
+    function isGraderOrAdmin() {
+      return isAuthenticated() &&
+        (get(/databases/$(database)/documents/users/$(request.auth.uid)).data.access == "admin" ||
+        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.access == "grader");
+    }
+
     // Allow read/write access to users for their own user data
     match /users/{userId} {
       allow read: if isAuthenticated() && request.auth.uid == userId;
@@ -62,6 +68,41 @@ service cloud.firestore {
 
     match /{somePath=**}/frqResponses/{frqResponse} {
       allow read: if isGraderOrMemberOrAdmin();
+    }
+
+    // Digital testing FRQs deliberately use separate stores. Templates are
+    // published prompts, the queue contains only ungraded responses, and a
+    // grading result is kept separately for the student's dashboard.
+    match /frqTemplates/{templateId} {
+      allow read: if true;
+      allow create, update, delete: if isAdmin();
+    }
+
+    match /gradableFrqSubmissions/{submissionId} {
+      allow get, list: if isGraderOrAdmin() ||
+        (isAuthenticated() && resource.data.studentId == request.auth.uid);
+      allow create: if isAuthenticated()
+        && request.resource.data.keys().hasOnly(['templateId', 'studentId', 'responses', 'submittedAt'])
+        && request.resource.data.templateId is string
+        && request.resource.data.studentId == request.auth.uid
+        && request.resource.data.responses is list
+        && exists(/databases/$(database)/documents/frqTemplates/$(request.resource.data.templateId));
+      allow delete: if isGraderOrAdmin();
+    }
+
+    match /gradedFrqSubmissions/{resultId} {
+      allow get, list: if isGraderOrAdmin() ||
+        (isAuthenticated() && resource.data.studentId == request.auth.uid);
+      allow create: if isGraderOrAdmin()
+        && request.resource.data.keys().hasOnly(['sourceSubmissionId', 'templateId', 'studentId', 'responses', 'submittedAt', 'score', 'feedback', 'graderId', 'gradedAt'])
+        && request.resource.data.sourceSubmissionId is string
+        && request.resource.data.templateId is string
+        && request.resource.data.studentId is string
+        && request.resource.data.responses is list
+        && request.resource.data.score is string
+        && request.resource.data.feedback is string
+        && request.resource.data.graderId == request.auth.uid;
+      allow update, delete: if isGraderOrAdmin();
     }
     
     // Admins can read/write all user documents

--- a/src/app/admin/subject/[slug]/[unit]/frq/[id]/page.tsx
+++ b/src/app/admin/subject/[slug]/[unit]/frq/[id]/page.tsx
@@ -23,15 +23,7 @@ const Page = () => {
     }
 
     (async () => {
-      const docRef = doc(
-        db,
-        "subjects",
-        subject,
-        "units",
-        unitId,
-        "frqs",
-        frqId,
-      );
+      const docRef = doc(db, "frqTemplates", frqId);
 
       const docSnap = await getDoc(docRef);
       setFrqFound(docSnap.exists());

--- a/src/app/frq-feedback/[id]/page.tsx
+++ b/src/app/frq-feedback/[id]/page.tsx
@@ -17,22 +17,14 @@ const Page = () => {
     const fetchFeedback = async () => {
       setStatus("loading");
       try {
-        const docRef = doc(
-          db, 
-          "frq-feedback", 
-          frqId
-        );
+        const docRef = doc(db, "gradedFrqSubmissions", frqId);
         const docSnap = await getDoc(docRef);
 
-        if (docSnap.exists()) {
-          setStatus("found");
-        } else {
-          setStatus("not-found");
-        }
-        } catch (error: unknown) {
-          console.error("Error fetching FRQ feedback:", error);
-          setStatus("not-found");
-        }
+        setStatus(docSnap.exists() ? "found" : "not-found");
+      } catch (error: unknown) {
+        console.error("Error fetching FRQ feedback:", error);
+        setStatus("not-found");
+      }
     };
 
     void fetchFeedback();
@@ -42,12 +34,32 @@ const Page = () => {
     return <p>Loading...</p>;
   }
 
+  if (status === "not-found") {
+    return <p>Feedback not found.</p>;
+  }
+
   return (
-  <div className="px-8 py-12">
-    <FRQFeedbackRenderer 
-      feedbackFound={status === "found"} 
-    />
-  </div>
+    <div className="px-8 py-12">
+      {/*
+        A real `feedbackData` cannot be built from a GradedFRQSubmission yet, so
+        the renderer intentionally falls back to its mock data here.
+
+        FRQFeedbackDocument is rubric-shaped: layout.tsx derives the displayed
+        score by summing `feedback.questions[].gradingCriteria[].points` over
+        `frqs[].questions[].gradingCriteria[].points`, and dropdownContent.tsx
+        renders one row per criterion plus per-part feedback. A graded submission
+        stores only an aggregate `score` string ("3/6") and a single `feedback`
+        string, and its `templateId` resolves to an FRQTemplate that carries no
+        rubric criteria and no question/part tree.
+
+        Building a document from what is stored today would render 0/0 points
+        with empty rubric rows and drop the grader's written feedback entirely --
+        strictly more misleading than the fallback. Closing this needs either the
+        grading write side to persist per-criterion scores and per-part feedback,
+        or FRQFeedbackDocument to accept an aggregate score/feedback pair.
+      */}
+      <FRQFeedbackRenderer />
+    </div>
   );
 };
 

--- a/src/app/frq-feedback/[id]/page.tsx
+++ b/src/app/frq-feedback/[id]/page.tsx
@@ -17,7 +17,7 @@ const Page = () => {
     const fetchFeedback = async () => {
       setStatus("loading");
       try {
-        const docRef = doc(db, "frq-feedback", frqId);
+        const docRef = doc(db, "gradedFrqSubmissions", frqId);
         const docSnap = await getDoc(docRef);
 
         if (docSnap.exists()) {

--- a/src/app/frq-grading/[id]/page.tsx
+++ b/src/app/frq-grading/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import FRQGradingRenderer from "@/components/frq/gradingRenderer";
 import { db } from "@/lib/firebase";
-import type { FRQSubmission } from "@/types/frq";
+import type { GradableFRQSubmission } from "@/types/frq";
 import { doc, getDoc } from "firebase/firestore";
 import { useEffect, useState } from "react";
 
@@ -13,19 +13,19 @@ type PageProps = {
 };
 
 const Page = ({ params }: PageProps) => {
-  const [frq, setFrq] = useState<FRQSubmission | null>(null);
+  const [frq, setFrq] = useState<GradableFRQSubmission | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const fetchFrq = async () => {
       try {
-        const docRef = doc(db, "ungraded-frqs", params.id);
+        const docRef = doc(db, "gradableFrqSubmissions", params.id);
         const docSnap = await getDoc(docRef);
 
         if (docSnap.exists()) {
           setFrq({
             id: docSnap.id,
-            ...(docSnap.data() as FRQSubmission),
+            ...(docSnap.data() as GradableFRQSubmission),
           });
         } else {
           setFrq(null);

--- a/src/app/frq-grading/page.tsx
+++ b/src/app/frq-grading/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { db } from "@/lib/firebase";
-import { collection, getDocs } from "firebase/firestore";
+import { collection, getDocs, orderBy, query } from "firebase/firestore";
 import { useEffect, useState } from "react";
 
 const Page = () => {
@@ -10,8 +10,10 @@ const Page = () => {
 
   useEffect(() => {
     const fetchFrqs = async () => {
-      const collectionRef = collection(db, "ungraded-frqs");
-      const snapshot = await getDocs(collectionRef);
+      const collectionRef = collection(db, "gradableFrqSubmissions");
+      const snapshot = await getDocs(
+        query(collectionRef, orderBy("submittedAt", "desc")),
+      );
       setFrqIds(snapshot.docs.map((doc) => doc.id));
     };
 

--- a/src/app/subject/[slug]/(no-sidebar)/[unit]/frq/[id]/page.tsx
+++ b/src/app/subject/[slug]/(no-sidebar)/[unit]/frq/[id]/page.tsx
@@ -26,15 +26,9 @@ const Page = () => {
       setFrq(null);
 
       try {
-        const docRef = doc(
-          db,
-          "subjects",
-          subject,
-          "units",
-          unitId!,
-          "frqs",
-          frqId,
-        );
+        // FRQs are top-level templates, just as an MCQ test is fetched as one
+        // document before its questions are rendered.
+        const docRef = doc(db, "frqTemplates", frqId);
 
         const docSnap = await getDoc(docRef);
 

--- a/src/components/frq/gradingRenderer.tsx
+++ b/src/components/frq/gradingRenderer.tsx
@@ -1,34 +1,99 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
+import Link from "next/link";
+import {
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronUp,
+  LogOut,
+} from "lucide-react";
 import { doc, runTransaction, serverTimestamp } from "firebase/firestore";
-import { db } from "@/lib/firebase";
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { useUser } from "@/components/hooks/UserContext";
+import { db } from "@/lib/firebase";
 import type { GradableFRQSubmission } from "@/types/frq";
 
 type FRQGradingRendererProps = {
   frq: GradableFRQSubmission | null;
 };
 
+type MockFrq = { title: string; questionCount: number };
+type RubricItem = {
+  description: string;
+  earnedPoints: number;
+  possiblePoints: number;
+};
+
+const MOCK_FRQS: MockFrq[] = [
+  { title: "FRQ 1", questionCount: 3 },
+  { title: "FRQ 2", questionCount: 4 },
+  { title: "FRQ 3", questionCount: 2 },
+];
+
+const RUBRIC_ITEMS: RubricItem[] = [
+  {
+    description: "Answer draws a connection to the Great Demographic Shift",
+    earnedPoints: 0,
+    possiblePoints: 2,
+  },
+  {
+    description: "Answer mentions John Smith’s contributions",
+    earnedPoints: 0,
+    possiblePoints: 1,
+  },
+  {
+    description: "Answer is at least 27 paragraphs long",
+    earnedPoints: 1,
+    possiblePoints: 1,
+  },
+  {
+    description:
+      "Answer contains correct punctuation, capitalization, and supporting details",
+    earnedPoints: 2,
+    possiblePoints: 2,
+  },
+];
+
 const FRQGradingRenderer = ({ frq }: FRQGradingRendererProps) => {
   const { user } = useUser();
-  const [score, setScore] = useState("");
+  const [currentFrqIndex, setCurrentFrqIndex] = useState(0);
+  const [isNavigationOpen, setIsNavigationOpen] = useState(false);
   const [feedback, setFeedback] = useState("");
-  const [saving, setSaving] = useState(false);
+  const [savedFeedback, setSavedFeedback] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showPrompt, setShowPrompt] = useState(true);
 
-  if (!frq) {
-    return <div>FRQ not found.</div>;
-  }
+  if (!frq) return <div>FRQ not found.</div>;
 
-  const saveGrade = async () => {
-    if (!frq.id || !user || !score.trim() || !feedback.trim()) return;
+  const currentFrq = MOCK_FRQS[currentFrqIndex];
+  if (!currentFrq) return <div>No FRQs available.</div>;
 
-    setSaving(true);
+  const earnedPoints = RUBRIC_ITEMS.reduce(
+    (total, item) => total + item.earnedPoints,
+    0,
+  );
+  const possiblePoints = RUBRIC_ITEMS.reduce(
+    (total, item) => total + item.possiblePoints,
+    0,
+  );
+
+  const submitGradeReport = async () => {
+    if (!frq.id || !user || !feedback.trim()) return;
+
+    setIsSubmitting(true);
     try {
-      // The submission ID is the grade ID. A transaction makes the queue item
-      // a one-time claim: concurrent graders cannot create competing grades.
-      const resultRef = doc(db, "gradedFrqSubmissions", frq.id);
+      // Use the submission ID as the result ID and atomically claim the queue
+      // item. Firestore retries concurrent transactions, so only one grader
+      // can successfully issue a report for a submission.
       const queueRef = doc(db, "gradableFrqSubmissions", frq.id);
+      const resultRef = doc(db, "gradedFrqSubmissions", frq.id);
 
       await runTransaction(db, async (transaction) => {
         const [queueSnapshot, resultSnapshot] = await Promise.all([
@@ -47,62 +112,417 @@ const FRQGradingRenderer = ({ frq }: FRQGradingRendererProps) => {
           studentId: queuedSubmission.studentId,
           responses: queuedSubmission.responses,
           submittedAt: queuedSubmission.submittedAt,
-          score: score.trim(),
+          score: `${earnedPoints}/${possiblePoints}`,
           feedback: feedback.trim(),
           graderId: user.uid,
           gradedAt: serverTimestamp(),
         });
         transaction.delete(queueRef);
       });
-      window.alert("Grade and feedback saved.");
+
+      window.alert("Grade report submitted.");
     } catch (error) {
-      console.error("Error saving FRQ grade:", error);
+      console.error("Error submitting FRQ grade:", error);
       window.alert(
         error instanceof Error &&
           error.message === "This submission has already been graded."
           ? "This submission was just graded by someone else. Refresh the queue."
-          : "Unable to save the grade. Please try again.",
+          : "Unable to submit the grade report. Please try again.",
       );
     } finally {
-      setSaving(false);
+      setIsSubmitting(false);
     }
   };
 
   return (
-    <div className="mx-auto max-w-2xl space-y-4 p-6">
-      <h1 className="text-2xl font-bold">Grade FRQ submission</h1>
-      <pre className="whitespace-pre-wrap rounded border bg-gray-50 p-4">
-        {Object.entries(frq.responses)
-          .map(([questionId, response]) => `${questionId}:\n${response}`)
-          .join("\n\n")}
-      </pre>
-      <label className="block">
-        <span className="font-semibold">Score</span>
-        <input
-          className="mt-1 w-full rounded border p-2"
-          value={score}
-          onChange={(event) => setScore(event.target.value)}
+    <div className="flex min-h-screen flex-col border-t-[6px] border-black bg-white pb-14">
+      <GradingHeader
+        gradedQuestionCount={5}
+        totalQuestionCount={6}
+        isSubmitting={isSubmitting}
+        onSaveChanges={() => setSavedFeedback(feedback)}
+        onSubmitGradeReport={() => void submitGradeReport()}
+      />
+
+      <main className="grid flex-1 grid-cols-1 divide-y divide-gray-300 lg:grid-cols-2 lg:divide-x lg:divide-y-0">
+        <GraderResponsePanel
+          frqTitle={currentFrq.title}
+          feedback={feedback}
+          savedFeedback={savedFeedback}
+          onFeedbackChange={setFeedback}
         />
-      </label>
-      <label className="block">
-        <span className="font-semibold">Feedback</span>
-        <textarea
-          className="mt-1 w-full rounded border p-2"
-          rows={6}
-          value={feedback}
-          onChange={(event) => setFeedback(event.target.value)}
+        <StudentResponsePanel
+          frqTitle={currentFrq.title}
+          questionCount={currentFrq.questionCount}
+          responses={frq.responses}
+          showPrompt={showPrompt}
+          onShowPromptChange={() => setShowPrompt((visible) => !visible)}
         />
-      </label>
-      <button
-        type="button"
-        className="rounded bg-blue-700 px-4 py-2 font-semibold text-white disabled:opacity-60"
-        disabled={saving || !score.trim() || !feedback.trim()}
-        onClick={() => void saveGrade()}
-      >
-        {saving ? "Saving..." : "Save grade"}
-      </button>
+      </main>
+
+      <GradingFooter
+        currentFrqIndex={currentFrqIndex}
+        totalFrqs={MOCK_FRQS.length}
+        isFirstFrq={currentFrqIndex === 0}
+        isLastFrq={currentFrqIndex === MOCK_FRQS.length - 1}
+        isNavigationOpen={isNavigationOpen}
+        onNavigationOpenChange={setIsNavigationOpen}
+        onPrevious={() => setCurrentFrqIndex((index) => Math.max(index - 1, 0))}
+        onNext={() =>
+          setCurrentFrqIndex((index) =>
+            Math.min(index + 1, MOCK_FRQS.length - 1),
+          )
+        }
+        onJumpToFrq={(index) => {
+          if (index >= 0 && index < MOCK_FRQS.length) {
+            setCurrentFrqIndex(index);
+            setIsNavigationOpen(false);
+          }
+        }}
+      />
     </div>
   );
 };
+
+function GradingHeader({
+  gradedQuestionCount,
+  totalQuestionCount,
+  isSubmitting,
+  onSaveChanges,
+  onSubmitGradeReport,
+}: {
+  gradedQuestionCount: number;
+  totalQuestionCount: number;
+  isSubmitting: boolean;
+  onSaveChanges: () => void;
+  onSubmitGradeReport: () => void;
+}) {
+  return (
+    <header className="flex min-h-[72px] items-center border-b border-dashed border-gray-400 bg-white px-10 py-3">
+      <div className="flex flex-1 items-center gap-4">
+        <button
+          type="button"
+          disabled={isSubmitting}
+          onClick={onSubmitGradeReport}
+          className="min-w-[176px] rounded-full bg-[#294ad1] px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#203cad] disabled:opacity-50"
+        >
+          {isSubmitting ? "Submitting..." : "Submit Grade Report"}
+        </button>
+        <button
+          type="button"
+          onClick={onSaveChanges}
+          className="min-w-[176px] rounded-full bg-[#294ad1] px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#203cad]"
+        >
+          Save Changes
+        </button>
+      </div>
+      <div className="flex flex-1 justify-center">
+        <p className="text-sm font-semibold text-gray-900">
+          {gradedQuestionCount}/{totalQuestionCount} Questions Graded
+        </p>
+      </div>
+      <div className="flex flex-1 justify-end">
+        <Link
+          href="/admin"
+          className="flex items-center gap-2 text-sm font-semibold text-red-500 transition-colors hover:text-red-600 hover:underline"
+        >
+          <LogOut aria-hidden="true" size={19} strokeWidth={2} />
+          Return To Admin Dashboard
+        </Link>
+      </div>
+    </header>
+  );
+}
+
+function GraderResponsePanel({
+  frqTitle,
+  feedback,
+  savedFeedback,
+  onFeedbackChange,
+}: {
+  frqTitle: string;
+  feedback: string;
+  savedFeedback: string;
+  onFeedbackChange: (feedback: string) => void;
+}) {
+  return (
+    <section className="px-10 py-8">
+      <h2 className="mb-5 text-base font-semibold">
+        {frqTitle} | Question A | Grader Response
+      </h2>
+      <QuestionHeader label="A" points="3/6 Points" expanded />
+      <div className="space-y-1">
+        {RUBRIC_ITEMS.map((item) => (
+          <RubricRow key={item.description} item={item} />
+        ))}
+      </div>
+      <div className="mt-4 min-h-[150px] rounded-md border border-gray-300">
+        <div className="flex h-10 items-center gap-3 border-b border-gray-300 px-3 text-sm">
+          <button type="button" className="font-bold">
+            B
+          </button>
+          <button type="button" className="italic">
+            I
+          </button>
+          <button type="button" className="underline">
+            U
+          </button>
+          <span>Ω</span>
+        </div>
+        <textarea
+          aria-label="Grader feedback"
+          value={feedback}
+          placeholder="Grader feedback will be entered here."
+          onChange={(event) => onFeedbackChange(event.target.value)}
+          className="min-h-[110px] w-full resize-y p-3 text-sm outline-none"
+        />
+        {savedFeedback === feedback && feedback && (
+          <p className="px-3 pb-2 text-xs text-green-700">
+            Changes saved locally.
+          </p>
+        )}
+      </div>
+      <QuestionHeader label="B" points="0/3 Points" />
+      <QuestionHeader label="C" points="0/3 Points" />
+    </section>
+  );
+}
+
+function RubricRow({ item }: { item: RubricItem }) {
+  return (
+    <div className="flex min-h-9 items-center gap-2">
+      <div className="min-w-0 flex-1 rounded-md border border-gray-300 px-3 py-1.5 text-sm">
+        <span className="block truncate">{item.description}</span>
+      </div>
+      <div className="flex shrink-0 items-center gap-1">
+        <span className="flex h-8 min-w-8 items-center justify-center rounded-md border border-gray-300 px-2">
+          {item.earnedPoints}
+        </span>
+        <span>/</span>
+        <span>{item.possiblePoints}</span>
+      </div>
+    </div>
+  );
+}
+
+function StudentResponsePanel({
+  frqTitle,
+  questionCount,
+  responses,
+  showPrompt,
+  onShowPromptChange,
+}: {
+  frqTitle: string;
+  questionCount: number;
+  responses: Record<string, string>;
+  showPrompt: boolean;
+  onShowPromptChange: () => void;
+}) {
+  return (
+    <section className="px-10 py-8">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-base font-semibold">
+          {frqTitle} | {questionCount} Questions
+        </h2>
+        <button
+          type="button"
+          onClick={onShowPromptChange}
+          className="rounded-md bg-black px-5 py-2 text-sm font-semibold text-white transition-colors hover:bg-gray-800"
+        >
+          {showPrompt ? "Hide Prompt" : "Show Prompt"}
+        </button>
+      </div>
+      <QuestionHeader label="A" expanded />
+      {showPrompt && (
+        <div className="mb-5 text-sm leading-6 text-gray-900">
+          <p className="mb-4">
+            The demographic transition model can be used to theorize changes in
+            a country&apos;s total population over time.
+          </p>
+          <p className="mb-3 font-medium">
+            Respond to parts A, B, C, D, E, F, and G.
+          </p>
+          <ol className="space-y-2">
+            <li>
+              <strong>A.</strong> Referring to Figure 1, identify the stage of
+              the Demographic Transition Model that this country is most likely
+              in.
+            </li>
+            <li>
+              <strong>B.</strong> Explain one social cause of the transition
+              between Stage 2 and Stage 3.
+            </li>
+            <li>
+              <strong>C.</strong> Define the term pro-natalist policy.
+            </li>
+            <li>
+              <strong>D.</strong> Explain the change in cause of death between
+              Stage 3 and Stage 4.
+            </li>
+          </ol>
+        </div>
+      )}
+      <div className="min-h-[260px] rounded-md border border-gray-400 p-4 text-sm leading-6">
+        {Object.entries(responses).map(([questionId, response]) => (
+          <div key={questionId} className="mb-4 last:mb-0">
+            <p className="font-semibold">{questionId}</p>
+            <p className="whitespace-pre-wrap">{response || "No response."}</p>
+          </div>
+        ))}
+      </div>
+      <QuestionHeader label="B" />
+      <QuestionHeader label="C" />
+    </section>
+  );
+}
+
+function QuestionHeader({
+  label,
+  points,
+  expanded = false,
+}: {
+  label: string;
+  points?: string;
+  expanded?: boolean;
+}) {
+  const Icon = expanded ? ChevronDown : ChevronRight;
+  return (
+    <button
+      type="button"
+      aria-expanded={expanded}
+      className="mb-3 flex h-9 w-full items-center justify-between bg-gray-100 pr-3 text-left"
+    >
+      <div className="flex h-full items-center">
+        <span className="flex h-full w-9 items-center justify-center bg-black font-bold text-white">
+          {label}
+        </span>
+        {points && <span className="px-3 font-semibold">{points}</span>}
+      </div>
+      <Icon aria-hidden="true" className="size-5" />
+    </button>
+  );
+}
+
+function GradingFooter({
+  currentFrqIndex,
+  totalFrqs,
+  isFirstFrq,
+  isLastFrq,
+  isNavigationOpen,
+  onNavigationOpenChange,
+  onPrevious,
+  onNext,
+  onJumpToFrq,
+}: {
+  currentFrqIndex: number;
+  totalFrqs: number;
+  isFirstFrq: boolean;
+  isLastFrq: boolean;
+  isNavigationOpen: boolean;
+  onNavigationOpenChange: (open: boolean) => void;
+  onPrevious: () => void;
+  onNext: () => void;
+  onJumpToFrq: (index: number) => void;
+}) {
+  return (
+    <footer className="fixed bottom-0 left-0 z-50 flex h-14 w-full items-center justify-between border-t-2 border-gray-300 bg-white px-8">
+      <p className="font-semibold">AP Human Geography Practice FRQ</p>
+      <div className="absolute left-1/2 flex -translate-x-1/2 items-center gap-2">
+        <FooterIconButton
+          label="Previous FRQ"
+          disabled={isFirstFrq}
+          onClick={onPrevious}
+        >
+          <ChevronLeft aria-hidden="true" className="size-5" />
+        </FooterIconButton>
+        <Popover open={isNavigationOpen} onOpenChange={onNavigationOpenChange}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className="flex items-center gap-1 rounded-md bg-black px-4 py-2 text-sm font-bold text-white transition-colors hover:bg-gray-800"
+            >
+              Question {currentFrqIndex + 1} of {totalFrqs}
+              <ChevronUp aria-hidden="true" className="size-4" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent align="center" side="top" className="w-40 p-2">
+            <div className="flex flex-col gap-2">
+              {Array.from({ length: totalFrqs }, (_, index) => (
+                <button
+                  key={index}
+                  type="button"
+                  onClick={() => onJumpToFrq(index)}
+                  className={`rounded-md px-3 py-2 text-left text-sm transition-colors ${index === currentFrqIndex ? "bg-[#294ad1] font-bold text-white" : "bg-gray-100 hover:bg-gray-200"}`}
+                >
+                  FRQ {index + 1}
+                </button>
+              ))}
+            </div>
+          </PopoverContent>
+        </Popover>
+        <FooterIconButton
+          label="Next FRQ"
+          disabled={isLastFrq}
+          onClick={onNext}
+        >
+          <ChevronRight aria-hidden="true" className="size-5" />
+        </FooterIconButton>
+      </div>
+      <div className="flex items-center gap-3">
+        <FooterNavigationButton disabled={isFirstFrq} onClick={onPrevious}>
+          Back
+        </FooterNavigationButton>
+        <FooterNavigationButton disabled={isLastFrq} onClick={onNext}>
+          Next
+        </FooterNavigationButton>
+      </div>
+    </footer>
+  );
+}
+
+function FooterIconButton({
+  label,
+  disabled,
+  onClick,
+  children,
+}: {
+  label: string;
+  disabled: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      disabled={disabled}
+      onClick={onClick}
+      className="rounded-md bg-black p-2 text-white transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
+    >
+      {children}
+    </button>
+  );
+}
+
+function FooterNavigationButton({
+  disabled,
+  onClick,
+  children,
+}: {
+  disabled: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className="rounded-full bg-[#294ad1] px-6 py-2 font-bold text-white transition-colors hover:bg-[#203cad] disabled:cursor-not-allowed disabled:opacity-40"
+    >
+      {children}
+    </button>
+  );
+}
 
 export default FRQGradingRenderer;

--- a/src/components/frq/gradingRenderer.tsx
+++ b/src/components/frq/gradingRenderer.tsx
@@ -1,15 +1,89 @@
-import type { FRQSubmission } from "@/types/frq";
+"use client";
+
+import { useState } from "react";
+import { collection, doc, serverTimestamp, writeBatch } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import { useUser } from "@/components/hooks/UserContext";
+import type { GradableFRQSubmission } from "@/types/frq";
 
 type FRQGradingRendererProps = {
-  frq: FRQSubmission | null;
+  frq: GradableFRQSubmission | null;
 };
 
 const FRQGradingRenderer = ({ frq }: FRQGradingRendererProps) => {
+  const { user } = useUser();
+  const [score, setScore] = useState("");
+  const [feedback, setFeedback] = useState("");
+  const [saving, setSaving] = useState(false);
+
   if (!frq) {
     return <div>FRQ not found.</div>;
   }
 
-  return <div>FRQ found. Grading page loaded successfully.</div>;
+  const saveGrade = async () => {
+    if (!frq.id || !user || !score.trim() || !feedback.trim()) return;
+
+    setSaving(true);
+    try {
+      const batch = writeBatch(db);
+      const resultRef = doc(collection(db, "gradedFrqSubmissions"));
+      const queueRef = doc(db, "gradableFrqSubmissions", frq.id);
+
+      batch.set(resultRef, {
+        sourceSubmissionId: frq.id,
+        templateId: frq.templateId,
+        studentId: frq.studentId,
+        responses: frq.responses,
+        submittedAt: frq.submittedAt,
+        score: score.trim(),
+        feedback: feedback.trim(),
+        graderId: user.uid,
+        gradedAt: serverTimestamp(),
+      });
+      batch.delete(queueRef);
+      await batch.commit();
+      window.alert("Grade and feedback saved.");
+    } catch (error) {
+      console.error("Error saving FRQ grade:", error);
+      window.alert("Unable to save the grade. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-4 p-6">
+      <h1 className="text-2xl font-bold">Grade FRQ submission</h1>
+      <pre className="whitespace-pre-wrap rounded border bg-gray-50 p-4">
+        {frq.responses.join("\n\n")}
+      </pre>
+      <label className="block">
+        <span className="font-semibold">Score</span>
+        <input
+          className="mt-1 w-full rounded border p-2"
+          value={score}
+          onChange={(event) => setScore(event.target.value)}
+        />
+      </label>
+      <label className="block">
+        <span className="font-semibold">Feedback</span>
+        <textarea
+          className="mt-1 w-full rounded border p-2"
+          rows={6}
+          value={feedback}
+          onChange={(event) => setFeedback(event.target.value)}
+        />
+      </label>
+      <button
+        type="button"
+        className="rounded bg-blue-700 px-4 py-2 font-semibold text-white disabled:opacity-60"
+        disabled={saving || !score.trim() || !feedback.trim()}
+        onClick={() => void saveGrade()}
+      >
+        {saving ? "Saving..." : "Save grade"}
+      </button>
+    </div>
+  );
 };
 
 export default FRQGradingRenderer;

--- a/src/components/frq/gradingRenderer.tsx
+++ b/src/components/frq/gradingRenderer.tsx
@@ -1,12 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import {
-  collection,
-  doc,
-  serverTimestamp,
-  writeBatch,
-} from "firebase/firestore";
+import { doc, runTransaction, serverTimestamp } from "firebase/firestore";
 import { db } from "@/lib/firebase";
 import { useUser } from "@/components/hooks/UserContext";
 import type { GradableFRQSubmission } from "@/types/frq";
@@ -30,27 +25,44 @@ const FRQGradingRenderer = ({ frq }: FRQGradingRendererProps) => {
 
     setSaving(true);
     try {
-      const batch = writeBatch(db);
-      const resultRef = doc(collection(db, "gradedFrqSubmissions"));
+      // The submission ID is the grade ID. A transaction makes the queue item
+      // a one-time claim: concurrent graders cannot create competing grades.
+      const resultRef = doc(db, "gradedFrqSubmissions", frq.id);
       const queueRef = doc(db, "gradableFrqSubmissions", frq.id);
 
-      batch.set(resultRef, {
-        sourceSubmissionId: frq.id,
-        templateId: frq.templateId,
-        studentId: frq.studentId,
-        responses: frq.responses,
-        submittedAt: frq.submittedAt,
-        score: score.trim(),
-        feedback: feedback.trim(),
-        graderId: user.uid,
-        gradedAt: serverTimestamp(),
+      await runTransaction(db, async (transaction) => {
+        const [queueSnapshot, resultSnapshot] = await Promise.all([
+          transaction.get(queueRef),
+          transaction.get(resultRef),
+        ]);
+
+        if (!queueSnapshot.exists() || resultSnapshot.exists()) {
+          throw new Error("This submission has already been graded.");
+        }
+
+        const queuedSubmission = queueSnapshot.data() as GradableFRQSubmission;
+        transaction.set(resultRef, {
+          sourceSubmissionId: frq.id,
+          templateId: queuedSubmission.templateId,
+          studentId: queuedSubmission.studentId,
+          responses: queuedSubmission.responses,
+          submittedAt: queuedSubmission.submittedAt,
+          score: score.trim(),
+          feedback: feedback.trim(),
+          graderId: user.uid,
+          gradedAt: serverTimestamp(),
+        });
+        transaction.delete(queueRef);
       });
-      batch.delete(queueRef);
-      await batch.commit();
       window.alert("Grade and feedback saved.");
     } catch (error) {
       console.error("Error saving FRQ grade:", error);
-      window.alert("Unable to save the grade. Please try again.");
+      window.alert(
+        error instanceof Error &&
+          error.message === "This submission has already been graded."
+          ? "This submission was just graded by someone else. Refresh the queue."
+          : "Unable to save the grade. Please try again.",
+      );
     } finally {
       setSaving(false);
     }

--- a/src/components/frq/gradingRenderer.tsx
+++ b/src/components/frq/gradingRenderer.tsx
@@ -18,21 +18,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { useUser } from "@/components/hooks/UserContext";
-import Link from "next/link";
-import {
-  ChevronDown,
-  ChevronLeft,
-  ChevronRight,
-  ChevronUp,
-  LogOut,
-} from "lucide-react";
-
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import type { FRQSubmission, GradableFRQSubmission } from "@/types/frq";
+import type { GradableFRQSubmission } from "@/types/frq";
 
 type FRQGradingRendererProps = {
   frq: GradableFRQSubmission | null;
@@ -265,17 +251,6 @@ function GraderResponsePanel({
         {frqTitle} | Question A | Grader Response
       </h2>
       <QuestionHeader label="A" points="3/6 Points" expanded />
-      <QuestionHeader label="A" points="3/6 Points" expanded />
-    </section>
-  );
-}
-}: GraderResponsePanelProps) {
-  return (
-    <section className="px-10 py-8">
-      <h2 className="mb-5 text-base font-semibold">
-        {frqTitle} | Question A | Grader Response
-      </h2>
-      <QuestionHeader label="A" points="3/6 Points" expanded />
       <div className="space-y-1">
         {RUBRIC_ITEMS.map((item) => (
           <RubricRow key={item.description} item={item} />
@@ -366,8 +341,8 @@ function StudentResponsePanel({
 
       <div className="mb-5 text-sm leading-6 text-gray-900">
         <p className="mb-4">
-          The demographic transition model can be used to theorize
-          changes in a country&apos;s total population over time.
+          The demographic transition model can be used to theorize changes in a
+          country&apos;s total population over time.
         </p>
 
         <p className="mb-3 font-medium">
@@ -376,14 +351,13 @@ function StudentResponsePanel({
 
         <ol className="space-y-2">
           <li>
-            <strong>A.</strong> Referring to Figure 1, identify the
-            stage of the Demographic Transition Model that this country
-            is most likely in.
+            <strong>A.</strong> Referring to Figure 1, identify the stage of the
+            Demographic Transition Model that this country is most likely in.
           </li>
 
           <li>
-            <strong>B.</strong> Explain one social cause of the
-            transition between Stage 2 and Stage 3.
+            <strong>B.</strong> Explain one social cause of the transition
+            between Stage 2 and Stage 3.
           </li>
 
           <li>
@@ -391,8 +365,8 @@ function StudentResponsePanel({
           </li>
 
           <li>
-            <strong>D.</strong> Explain the change in cause of death
-            between Stage 3 and Stage 4.
+            <strong>D.</strong> Explain the change in cause of death between
+            Stage 3 and Stage 4.
           </li>
         </ol>
       </div>
@@ -400,18 +374,18 @@ function StudentResponsePanel({
       <div className="min-h-[260px] rounded-md border border-gray-400 p-4 text-sm leading-6">
         <p className="mb-4">
           This is temporary student response content used to match the
-          grading-page mockup. The actual FRQ response will be loaded
-          in a future work item.
+          grading-page mockup. The actual FRQ response will be loaded in a
+          future work item.
         </p>
 
         <p className="mb-4">
-          The student response area will use the advanced textbox
-          renderer after its required properties are confirmed.
+          The student response area will use the advanced textbox renderer after
+          its required properties are confirmed.
         </p>
 
         <p>
-          Navigating through the footer changes the displayed FRQ title
-          and question count.
+          Navigating through the footer changes the displayed FRQ title and
+          question count.
         </p>
 
         {/*
@@ -477,9 +451,7 @@ function GradingFooter({
 }: GradingFooterProps) {
   return (
     <footer className="fixed bottom-0 left-0 z-50 flex h-14 w-full items-center justify-between border-t-2 border-gray-300 bg-white px-8">
-      <p className="font-semibold">
-        AP Human Geography Practice FRQ
-      </p>
+      <p className="font-semibold">AP Human Geography Practice FRQ</p>
 
       <div className="absolute left-1/2 flex -translate-x-1/2 items-center gap-2">
         <FooterIconButton

--- a/src/components/frq/gradingRenderer.tsx
+++ b/src/components/frq/gradingRenderer.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { useState } from "react";
-import { collection, doc, serverTimestamp, writeBatch } from "firebase/firestore";
+import {
+  collection,
+  doc,
+  serverTimestamp,
+  writeBatch,
+} from "firebase/firestore";
 import { db } from "@/lib/firebase";
 import { useUser } from "@/components/hooks/UserContext";
 import type { GradableFRQSubmission } from "@/types/frq";
@@ -55,7 +60,9 @@ const FRQGradingRenderer = ({ frq }: FRQGradingRendererProps) => {
     <div className="mx-auto max-w-2xl space-y-4 p-6">
       <h1 className="text-2xl font-bold">Grade FRQ submission</h1>
       <pre className="whitespace-pre-wrap rounded border bg-gray-50 p-4">
-        {frq.responses.join("\n\n")}
+        {Object.entries(frq.responses)
+          .map(([questionId, response]) => `${questionId}:\n${response}`)
+          .join("\n\n")}
       </pre>
       <label className="block">
         <span className="font-semibold">Score</span>

--- a/src/components/frq/testRenderer.tsx
+++ b/src/components/frq/testRenderer.tsx
@@ -5,6 +5,9 @@ import FRQFooter from "@/components/frq/FRQFooter";
 import { Bookmark, LogOut } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
+import { addDoc, collection, serverTimestamp } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import { useUser } from "@/components/hooks/UserContext";
 
 type FRQTestRendererProps = {
   frq: Record<string, unknown> | null;
@@ -28,8 +31,13 @@ const FRQTestRenderer = ({
   error = null,
 }: FRQTestRendererProps) => {
   const router = useRouter();
+  const { user } = useUser();
+  const [submitting, setSubmitting] = useState(false);
   const [currentFRQIndex, setCurrentFRQIndex] = useState(0);
-  const questions = mockFRQs;
+  const templateQuestions = Array.isArray(frq?.questions)
+    ? (frq.questions as MockFRQ[])
+    : mockFRQs;
+  const questions = templateQuestions.length > 0 ? templateQuestions : mockFRQs;
   const [responses, setResponses] = useState<string[]>(
   mockFRQs.map(() => ""),
 );
@@ -221,6 +229,32 @@ const downloadResponsesAsPdf = () => {
   }, 250);
 };
 
+const submitForGrading = async () => {
+  const templateId = typeof frq?.id === "string" ? frq.id : null;
+
+  if (!user || !templateId) {
+    window.alert("Please sign in before submitting this FRQ for grading.");
+    return;
+  }
+
+  setSubmitting(true);
+  try {
+    await addDoc(collection(db, "gradableFrqSubmissions"), {
+      templateId,
+      studentId: user.uid,
+      responses,
+      submittedAt: serverTimestamp(),
+    });
+    setShowSubmissionModal(false);
+    window.alert("Your FRQ was submitted for grading.");
+  } catch (submissionError) {
+    console.error("Error submitting FRQ for grading:", submissionError);
+    window.alert("We could not submit your FRQ. Please try again.");
+  } finally {
+    setSubmitting(false);
+  }
+};
+
 
 const submissionModal = showSubmissionModal ? (
   <div
@@ -259,14 +293,10 @@ const submissionModal = showSubmissionModal ? (
         <button
           type="button"
           className="rounded bg-blue-700 px-5 py-3 font-semibold text-white"
-          onClick={() => {
-            setShowSubmissionModal(false);
-            window.alert(
-              "Submission for grading will be connected to the backend later.",
-            );
-          }}
+          onClick={() => void submitForGrading()}
+          disabled={submitting}
         >
-          Submit for Grading
+          {submitting ? "Submitting..." : "Submit for Grading"}
         </button>
 
         <button

--- a/src/components/frq/testRenderer.tsx
+++ b/src/components/frq/testRenderer.tsx
@@ -42,7 +42,7 @@ const FRQTestRenderer = ({
   const { user } = useUser();
   const [submitting, setSubmitting] = useState(false);
   const [currentFRQIndex, setCurrentFRQIndex] = useState(0);
-  const templateQuestions = useMemo(
+  const templateQuestions = useMemo<FRQQuestion[] | null>(
     () => (Array.isArray(frq?.questions) ? frq.questions : null),
     [frq],
   );
@@ -52,7 +52,7 @@ const FRQTestRenderer = ({
       !templateQuestions.every(isTemplateQuestion));
   const questions = hasInvalidTemplateQuestions
     ? emptyQuestions
-    : ((templateQuestions as FRQQuestion[] | null) ?? mockFRQs);
+    : (templateQuestions ?? mockFRQs);
   const [responses, setResponses] = useState<Record<string, string>>({});
 
   useEffect(() => {

--- a/src/components/frq/testRenderer.tsx
+++ b/src/components/frq/testRenderer.tsx
@@ -4,7 +4,7 @@ import FRQResponseEditor from "@/components/frq/responseEditor";
 import FRQFooter from "@/components/frq/FRQFooter";
 import { Bookmark, LogOut } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { addDoc, collection, serverTimestamp } from "firebase/firestore";
 import { db } from "@/lib/firebase";
 import { useUser } from "@/components/hooks/UserContext";
@@ -15,15 +15,23 @@ type FRQTestRendererProps = {
   error?: string | null;
 };
 
-type MockFRQ = {
+type FRQQuestion = {
+  id: string;
   title: string;
 };
 
-const mockFRQs: MockFRQ[] = [
-  { title: "Demographic Transition Model" },
-  { title: "Urban Land Use" },
-  { title: "Agricultural Regions" },
+const mockFRQs: FRQQuestion[] = [
+  { id: "mock-demographic-transition", title: "Demographic Transition Model" },
+  { id: "mock-urban-land-use", title: "Urban Land Use" },
+  { id: "mock-agricultural-regions", title: "Agricultural Regions" },
 ];
+const emptyQuestions: FRQQuestion[] = [];
+
+const isTemplateQuestion = (value: unknown): value is FRQQuestion =>
+  typeof value === "object" &&
+  value !== null &&
+  typeof (value as FRQQuestion).id === "string" &&
+  typeof (value as FRQQuestion).title === "string";
 
 const FRQTestRenderer = ({
   frq,
@@ -34,59 +42,73 @@ const FRQTestRenderer = ({
   const { user } = useUser();
   const [submitting, setSubmitting] = useState(false);
   const [currentFRQIndex, setCurrentFRQIndex] = useState(0);
-  const templateQuestions = Array.isArray(frq?.questions)
-    ? (frq.questions as MockFRQ[])
-    : mockFRQs;
-  const questions = templateQuestions.length > 0 ? templateQuestions : mockFRQs;
-  const [responses, setResponses] = useState<string[]>(
-  mockFRQs.map(() => ""),
-);
-const [markedForReview, setMarkedForReview] = useState<
-  Record<number, boolean>
->({});
+  const templateQuestions = useMemo(
+    () => (Array.isArray(frq?.questions) ? frq.questions : null),
+    [frq],
+  );
+  const hasInvalidTemplateQuestions =
+    templateQuestions !== null &&
+    (templateQuestions.length === 0 ||
+      !templateQuestions.every(isTemplateQuestion));
+  const questions = hasInvalidTemplateQuestions
+    ? emptyQuestions
+    : ((templateQuestions as FRQQuestion[] | null) ?? mockFRQs);
+  const [responses, setResponses] = useState<Record<string, string>>({});
 
-const [timeRemaining, setTimeRemaining] = useState(
-  1 * 60 * 60 + 30 * 60,
-);
-const [timerHidden, setTimerHidden] = useState(false);
-const [showTimeUpPopup, setShowTimeUpPopup] = useState(false);
-const [showReviewPage, setShowReviewPage] = useState(false);
-const [showSubmissionModal, setShowSubmissionModal] =
-  useState(false);
-
-useEffect(() => {
-  const timer = window.setInterval(() => {
-    setTimeRemaining((currentTime) =>
-      currentTime > 0 ? currentTime - 1 : 0,
+  useEffect(() => {
+    setResponses((currentResponses) =>
+      Object.fromEntries(
+        questions.map((question) => [
+          question.id,
+          currentResponses[question.id] ?? "",
+        ]),
+      ),
     );
-  }, 1000);
+    setCurrentFRQIndex(0);
+  }, [questions]);
+  const [markedForReview, setMarkedForReview] = useState<
+    Record<number, boolean>
+  >({});
 
-  return () => {
-    window.clearInterval(timer);
-  };
-}, []);
+  const [timeRemaining, setTimeRemaining] = useState(1 * 60 * 60 + 30 * 60);
+  const [timerHidden, setTimerHidden] = useState(false);
+  const [showTimeUpPopup, setShowTimeUpPopup] = useState(false);
+  const [showReviewPage, setShowReviewPage] = useState(false);
+  const [showSubmissionModal, setShowSubmissionModal] = useState(false);
 
-useEffect(() => {
-  if (timeRemaining === 0) {
-    setShowTimeUpPopup(true);
-  }
-}, [timeRemaining]);
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      setTimeRemaining((currentTime) =>
+        currentTime > 0 ? currentTime - 1 : 0,
+      );
+    }, 1000);
 
-const formattedTime = `${Math.floor(timeRemaining / 3600)}:${String(
-  Math.floor((timeRemaining % 3600) / 60),
-).padStart(2, "0")}:${String(timeRemaining % 60).padStart(2, "0")}`;
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (timeRemaining === 0) {
+      setShowTimeUpPopup(true);
+    }
+  }, [timeRemaining]);
+
+  const formattedTime = `${Math.floor(timeRemaining / 3600)}:${String(
+    Math.floor((timeRemaining % 3600) / 60),
+  ).padStart(2, "0")}:${String(timeRemaining % 60).padStart(2, "0")}`;
 
   const currentFRQ = questions[currentFRQIndex];
   const hasBackendData = Boolean(frq);
 
   const handleNext = () => {
-  if (currentFRQIndex === questions.length - 1) {
-    setShowReviewPage(true);
-    return;
-  }
+    if (currentFRQIndex === questions.length - 1) {
+      setShowReviewPage(true);
+      return;
+    }
 
-  setCurrentFRQIndex((currentIndex) => currentIndex + 1);
-};
+    setCurrentFRQIndex((currentIndex) => currentIndex + 1);
+  };
 
   if (loading) {
     return <p>Loading FRQ test...</p>;
@@ -96,84 +118,78 @@ const formattedTime = `${Math.floor(timeRemaining / 3600)}:${String(
     return <p>Failed to load FRQ test.</p>;
   }
 
+  if (hasInvalidTemplateQuestions) {
+    return <p>This FRQ template has invalid question identifiers.</p>;
+  }
+
   if (!currentFRQ) {
     return <p>FRQ test not found.</p>;
   }
 
   const timeUpModal = showTimeUpPopup ? (
-  <div
-    className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-    role="dialog"
-    aria-modal="true"
-    aria-labelledby="time-up-title"
-  >
-    <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
-      <h2 id="time-up-title" className="text-xl font-bold">
-        Time is up
-      </h2>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="time-up-title"
+    >
+      <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+        <h2 id="time-up-title" className="text-xl font-bold">
+          Time is up
+        </h2>
 
-      <p className="mt-3 text-sm text-gray-600">
-        Your time has ended. You can submit your test now or continue
-        working.
-      </p>
+        <p className="mt-3 text-sm text-gray-600">
+          Your time has ended. You can submit your test now or continue working.
+        </p>
 
-      <div className="mt-6 flex justify-end gap-3">
-        <button
-          type="button"
-          className="rounded border border-gray-400 px-4 py-2 font-semibold"
-          onClick={() => setShowTimeUpPopup(false)}
-        >
-          Continue Working
-        </button>
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            type="button"
+            className="rounded border border-gray-400 px-4 py-2 font-semibold"
+            onClick={() => setShowTimeUpPopup(false)}
+          >
+            Continue Working
+          </button>
 
-        <button
-          type="button"
-          className="rounded bg-blue-700 px-4 py-2 font-semibold text-white"
-          onClick={() => {
-            setShowTimeUpPopup(false);
-            window.alert(
-              "Final submission will be connected later.",
-            );
-          }}
-        >
-          Submit Test
-        </button>
+          <button
+            type="button"
+            className="rounded bg-blue-700 px-4 py-2 font-semibold text-white"
+            onClick={() => {
+              setShowTimeUpPopup(false);
+              window.alert("Final submission will be connected later.");
+            }}
+          >
+            Submit Test
+          </button>
+        </div>
       </div>
     </div>
-  </div>
-) : null;
-const downloadResponsesAsPdf = () => {
-  const printWindow = window.open(
-    "",
-    "_blank",
-    "width=900,height=700",
-  );
+  ) : null;
+  const downloadResponsesAsPdf = () => {
+    const printWindow = window.open("", "_blank", "width=900,height=700");
 
-  if (!printWindow) {
-    window.alert(
-      "The browser blocked the PDF window. Allow pop-ups and try again.",
-    );
-    return;
-  }
+    if (!printWindow) {
+      window.alert(
+        "The browser blocked the PDF window. Allow pop-ups and try again.",
+      );
+      return;
+    }
 
-  const getPlainText = (html: string) => {
-    const parsedDocument = new DOMParser().parseFromString(
-      html,
-      "text/html",
-    );
+    const getPlainText = (html: string) => {
+      const parsedDocument = new DOMParser().parseFromString(html, "text/html");
 
-    return parsedDocument.body.textContent?.trim() || "No response";
-  };
+      return parsedDocument.body.textContent?.trim() || "No response";
+    };
 
-  const printDocument = printWindow.document;
+    const printDocument = printWindow.document;
 
-  printDocument.title = "FRQ Responses";
-  printDocument.head.replaceChildren();
-  printDocument.body.replaceChildren();
+    printDocument.title = "FRQ Responses";
+    printDocument.head.replaceChildren();
+    printDocument.body.replaceChildren();
 
-  const styleElement = printDocument.createElement("style");
+    const styleElement = printDocument.createElement("style");
 
-  styleElement.textContent = `
+    styleElement.textContent = `
     body {
       margin: 40px;
       color: #111;
@@ -202,216 +218,212 @@ const downloadResponsesAsPdf = () => {
     }
   `;
 
-  printDocument.head.appendChild(styleElement);
+    printDocument.head.appendChild(styleElement);
 
-  const pageTitle = printDocument.createElement("h1");
-  pageTitle.textContent = "AP Human Geography FRQ Responses";
-  printDocument.body.appendChild(pageTitle);
+    const pageTitle = printDocument.createElement("h1");
+    pageTitle.textContent = "AP Human Geography FRQ Responses";
+    printDocument.body.appendChild(pageTitle);
 
-  questions.forEach((question, index) => {
-    const section = printDocument.createElement("section");
-    section.className = "response";
+    questions.forEach((question, index) => {
+      const section = printDocument.createElement("section");
+      section.className = "response";
 
-    const heading = printDocument.createElement("h2");
-    heading.textContent = `FRQ ${index + 1}: ${question.title}`;
+      const heading = printDocument.createElement("h2");
+      heading.textContent = `FRQ ${index + 1}: ${question.title}`;
 
-    const responseText = printDocument.createElement("p");
-    responseText.textContent = getPlainText(responses[index] ?? "");
+      const responseText = printDocument.createElement("p");
+      responseText.textContent = getPlainText(responses[question.id] ?? "");
 
-    section.append(heading, responseText);
-    printDocument.body.appendChild(section);
-  });
-
-  printWindow.focus();
-
-  window.setTimeout(() => {
-    printWindow.print();
-  }, 250);
-};
-
-const submitForGrading = async () => {
-  const templateId = typeof frq?.id === "string" ? frq.id : null;
-
-  if (!user || !templateId) {
-    window.alert("Please sign in before submitting this FRQ for grading.");
-    return;
-  }
-
-  setSubmitting(true);
-  try {
-    await addDoc(collection(db, "gradableFrqSubmissions"), {
-      templateId,
-      studentId: user.uid,
-      responses,
-      submittedAt: serverTimestamp(),
+      section.append(heading, responseText);
+      printDocument.body.appendChild(section);
     });
-    setShowSubmissionModal(false);
-    window.alert("Your FRQ was submitted for grading.");
-  } catch (submissionError) {
-    console.error("Error submitting FRQ for grading:", submissionError);
-    window.alert("We could not submit your FRQ. Please try again.");
-  } finally {
-    setSubmitting(false);
-  }
-};
 
+    printWindow.focus();
 
-const submissionModal = showSubmissionModal ? (
-  <div
-    className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50 p-4"
-    role="dialog"
-    aria-modal="true"
-    aria-labelledby="submission-title"
-  >
-    <div className="relative w-full max-w-lg rounded-lg bg-white p-6 shadow-xl">
-      <button
-        type="button"
-        aria-label="Close submission popup"
-        className="absolute right-4 top-3 text-2xl text-gray-500 hover:text-black"
-        onClick={() => setShowSubmissionModal(false)}
-      >
-        ×
-      </button>
+    window.setTimeout(() => {
+      printWindow.print();
+    }, 250);
+  };
 
-      <h2 id="submission-title" className="text-2xl font-bold">
-        Submit Your Test
-      </h2>
+  const submitForGrading = async () => {
+    const templateId = typeof frq?.id === "string" ? frq.id : null;
 
-      <p className="mt-3 text-sm text-gray-600">
-        Download a copy of your responses or submit them for grading.
-      </p>
+    if (!user || !templateId) {
+      window.alert("Please sign in before submitting this FRQ for grading.");
+      return;
+    }
 
-      <div className="mt-6 flex flex-col gap-3">
+    setSubmitting(true);
+    try {
+      await addDoc(collection(db, "gradableFrqSubmissions"), {
+        templateId,
+        studentId: user.uid,
+        responses,
+        submittedAt: serverTimestamp(),
+      });
+      setShowSubmissionModal(false);
+      window.alert("Your FRQ was submitted for grading.");
+    } catch (submissionError) {
+      console.error("Error submitting FRQ for grading:", submissionError);
+      window.alert("We could not submit your FRQ. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const submissionModal = showSubmissionModal ? (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="submission-title"
+    >
+      <div className="relative w-full max-w-lg rounded-lg bg-white p-6 shadow-xl">
         <button
           type="button"
-          className="rounded border border-blue-700 px-5 py-3 font-semibold text-blue-700"
-          onClick={downloadResponsesAsPdf}
+          aria-label="Close submission popup"
+          className="absolute right-4 top-3 text-2xl text-gray-500 hover:text-black"
+          onClick={() => setShowSubmissionModal(false)}
         >
-          Download Responses as PDF
+          ×
         </button>
 
-        <button
-          type="button"
-          className="rounded bg-blue-700 px-5 py-3 font-semibold text-white"
-          onClick={() => void submitForGrading()}
-          disabled={submitting}
-        >
-          {submitting ? "Submitting..." : "Submit for Grading"}
-        </button>
+        <h2 id="submission-title" className="text-2xl font-bold">
+          Submit Your Test
+        </h2>
 
-        <button
-  type="button"
-  className="rounded border border-black px-5 py-3 font-semibold text-black hover:bg-gray-100"
-  onClick={() => setShowSubmissionModal(false)}
->
-  Close
-</button>
+        <p className="mt-3 text-sm text-gray-600">
+          Download a copy of your responses or submit them for grading.
+        </p>
+
+        <div className="mt-6 flex flex-col gap-3">
+          <button
+            type="button"
+            className="rounded border border-blue-700 px-5 py-3 font-semibold text-blue-700"
+            onClick={downloadResponsesAsPdf}
+          >
+            Download Responses as PDF
+          </button>
+
+          <button
+            type="button"
+            className="rounded bg-blue-700 px-5 py-3 font-semibold text-white"
+            onClick={() => void submitForGrading()}
+            disabled={submitting}
+          >
+            {submitting ? "Submitting..." : "Submit for Grading"}
+          </button>
+
+          <button
+            type="button"
+            className="rounded border border-black px-5 py-3 font-semibold text-black hover:bg-gray-100"
+            onClick={() => setShowSubmissionModal(false)}
+          >
+            Close
+          </button>
+        </div>
       </div>
     </div>
-  </div>
-) : null;
+  ) : null;
 
   if (showReviewPage) {
-  return (
-    <main className="min-h-screen bg-gray-50 px-6 py-12 text-black">
-      {timeUpModal}
-      {submissionModal}
-      <div className="mx-auto max-w-5xl">
-        <h1 className="text-center text-4xl font-normal">
-          Check Your Work
-        </h1>
+    return (
+      <main className="min-h-screen bg-gray-50 px-6 py-12 text-black">
+        {timeUpModal}
+        {submissionModal}
+        <div className="mx-auto max-w-5xl">
+          <h1 className="text-center text-4xl font-normal">Check Your Work</h1>
 
-        <div className="mx-auto mt-6 max-w-2xl space-y-0.5 text-center text-base leading-5">
-  <p>Review your responses before submitting your test.</p>
-  <p>Select an FRQ number to return to that question.</p>
-</div>
+          <div className="mx-auto mt-6 max-w-2xl space-y-0.5 text-center text-base leading-5">
+            <p>Review your responses before submitting your test.</p>
+            <p>Select an FRQ number to return to that question.</p>
+          </div>
 
-        <section className="mt-8 rounded-xl bg-white p-8 shadow-lg">
-          <div className="flex flex-wrap items-center justify-between gap-4 border-b border-gray-300 pb-5">
-            <h2 className="text-xl font-bold">
-              Section II: Free-Response Questions
-            </h2>
+          <section className="mt-8 rounded-xl bg-white p-8 shadow-lg">
+            <div className="flex flex-wrap items-center justify-between gap-4 border-b border-gray-300 pb-5">
+              <h2 className="text-xl font-bold">
+                Section II: Free-Response Questions
+              </h2>
 
-            <div className="flex flex-wrap gap-6 text-sm">
-              <span className="flex items-center gap-2">
-                <span className="h-5 w-5 border-2 border-dashed border-gray-500" />
-                Unanswered
-              </span>
+              <div className="flex flex-wrap gap-6 text-sm">
+                <span className="flex items-center gap-2">
+                  <span className="h-5 w-5 border-2 border-dashed border-gray-500" />
+                  Unanswered
+                </span>
 
-              <span className="flex items-center gap-2">
-                <Bookmark
-                  size={20}
-                  fill="currentColor"
-                  className="text-red-600"
-                />
-                For Review
-              </span>
+                <span className="flex items-center gap-2">
+                  <Bookmark
+                    size={20}
+                    fill="currentColor"
+                    className="text-red-600"
+                  />
+                  For Review
+                </span>
+              </div>
             </div>
-          </div>
 
-          <div className="mt-8 flex flex-wrap items-center justify-start gap-10 py-6 pl-6">
-            {questions.map((question, index) => {
-              const response = responses[index] ?? "";
+            <div className="mt-8 flex flex-wrap items-center justify-start gap-10 py-6 pl-6">
+              {questions.map((question, index) => {
+                const response = responses[question.id] ?? "";
 
-              const isAnswered =
-                response
-                  .replace(/<[^>]*>/g, "")
-                  .replace(/&nbsp;/g, " ")
-                  .trim().length > 0;
+                const isAnswered =
+                  response
+                    .replace(/<[^>]*>/g, "")
+                    .replace(/&nbsp;/g, " ")
+                    .trim().length > 0;
 
-              const isMarked =
-                markedForReview[index] ?? false;
+                const isMarked = markedForReview[index] ?? false;
 
-              return (
-                <button
-                  key={question.title}
-                  type="button"
-                  className={`relative flex h-14 w-14 items-center justify-center text-xl font-bold ${
-                    isAnswered
-                      ? "bg-blue-700 text-white"
-                      : "border-2 border-dashed border-gray-500 bg-white text-black"
-                  }`}
-                  onClick={() => {
-                    setCurrentFRQIndex(index);
-                    setShowReviewPage(false);
-                  }}
-                >
-                  {index + 1}
+                return (
+                  <button
+                    key={question.id}
+                    type="button"
+                    className={`relative flex h-14 w-14 items-center justify-center text-xl font-bold ${
+                      isAnswered
+                        ? "bg-blue-700 text-white"
+                        : "border-2 border-dashed border-gray-500 bg-white text-black"
+                    }`}
+                    onClick={() => {
+                      setCurrentFRQIndex(index);
+                      setShowReviewPage(false);
+                    }}
+                  >
+                    {index + 1}
 
-                  {isMarked && (
-                    <Bookmark
-                      size={19}
-                      fill="currentColor"
-                      className="absolute -right-2 -top-2 text-red-600"
-                    />
-                  )}
-                </button>
-              );
-            })}
-          </div>
+                    {isMarked && (
+                      <Bookmark
+                        size={19}
+                        fill="currentColor"
+                        className="absolute -right-2 -top-2 text-red-600"
+                      />
+                    )}
+                  </button>
+                );
+              })}
+            </div>
 
-          <div className="mt-10 flex flex-wrap justify-end gap-3 border-t border-gray-300 pt-6">
-            <button
-              type="button"
-              className="rounded-full border border-blue-700 px-6 py-3 font-semibold text-blue-700"
-              onClick={() => setShowReviewPage(false)}
-            >
-              Return to Test
-            </button>
+            <div className="mt-10 flex flex-wrap justify-end gap-3 border-t border-gray-300 pt-6">
+              <button
+                type="button"
+                className="rounded-full border border-blue-700 px-6 py-3 font-semibold text-blue-700"
+                onClick={() => setShowReviewPage(false)}
+              >
+                Return to Test
+              </button>
 
-            <button
-              type="button"
-              className="rounded-full bg-blue-700 px-6 py-3 font-semibold text-white"
-              onClick={() => setShowSubmissionModal(true)}
-            >
-              Submit Test
-            </button>
-          </div>
-        </section>
-      </div>
-    </main>
-  );
-}
+              <button
+                type="button"
+                className="rounded-full bg-blue-700 px-6 py-3 font-semibold text-white"
+                onClick={() => setShowSubmissionModal(true)}
+              >
+                Submit Test
+              </button>
+            </div>
+          </section>
+        </div>
+      </main>
+    );
+  }
 
   return (
     <main className="min-h-screen w-full bg-white text-black">
@@ -424,37 +436,37 @@ const submissionModal = showSubmissionModal ? (
           </div>
 
           <div className="text-center">
-  <p className="font-sans text-lg font-bold">
-  {timerHidden ? "" : formattedTime}
-</p>
+            <p className="font-sans text-lg font-bold">
+              {timerHidden ? "" : formattedTime}
+            </p>
 
-  <button
-    type="button"
-    className="rounded border border-gray-400 px-2 py-0.5 text-xs"
-    onClick={() => setTimerHidden((currentValue) => !currentValue)}
-  >
-    {timerHidden ? "Show" : "Hide"}
-  </button>
-</div>
+            <button
+              type="button"
+              className="rounded border border-gray-400 px-2 py-0.5 text-xs"
+              onClick={() => setTimerHidden((currentValue) => !currentValue)}
+            >
+              {timerHidden ? "Show" : "Hide"}
+            </button>
+          </div>
 
           <button
-  type="button"
-  className="flex items-center gap-2 text-sm font-bold text-red-500"
-  onClick={() => router.back()}
->
-  <LogOut size={16} />
-  Exit Test
-</button>
+            type="button"
+            className="flex items-center gap-2 text-sm font-bold text-red-500"
+            onClick={() => router.back()}
+          >
+            <LogOut size={16} />
+            Exit Test
+          </button>
 
-<div
-  aria-hidden="true"
-  className="absolute bottom-0 left-0 h-[2px] w-full"
-  style={{
-    backgroundImage:
-      "repeating-linear-gradient(to right, #111 0 20px, transparent 20px 24px)",
-  }}
-/>
-</header>
+          <div
+            aria-hidden="true"
+            className="absolute bottom-0 left-0 h-[2px] w-full"
+            style={{
+              backgroundImage:
+                "repeating-linear-gradient(to right, #111 0 20px, transparent 20px 24px)",
+            }}
+          />
+        </header>
 
         <div className="grid flex-1 grid-cols-1 lg:grid-cols-2">
           <section className="border-b-2 border-solid border-gray-500 p-8 lg:border-b-0 lg:border-r-[3px]">
@@ -463,7 +475,7 @@ const submissionModal = showSubmissionModal ? (
             </div>
 
             <div className="mb-8">
-              <div className="mx-auto flex h-80 max-w-md items-end justify-center gap-1 border-l border-gray-300 border-b border-gray-300 px-6">
+              <div className="mx-auto flex h-80 max-w-md items-end justify-center gap-1 border-b border-l border-gray-300 border-gray-300 px-6">
                 {Array.from({ length: 17 }).map((_, index) => (
                   <div
                     key={`left-bar-${index}`}
@@ -509,67 +521,63 @@ const submissionModal = showSubmissionModal ? (
               </div>
               <p className="mt-3 text-center text-sm">Figure 2</p>
             </div>
-
-
           </section>
 
-
           <section className="p-8">
-          <div className="mb-6 w-full max-w-[50rem] bg-gray-100">
-  <div className="flex h-8 items-center">
-    <span className="flex h-8 w-8 items-center justify-center bg-black text-lg font-bold text-white">
-      {currentFRQIndex + 1}
-    </span>
+            <div className="mb-6 w-full max-w-[50rem] bg-gray-100">
+              <div className="flex h-8 items-center">
+                <span className="flex h-8 w-8 items-center justify-center bg-black text-lg font-bold text-white">
+                  {currentFRQIndex + 1}
+                </span>
 
-    <button
-      type="button"
-      aria-pressed={markedForReview[currentFRQIndex] ?? false}
-      className="flex h-full items-center gap-2 px-4 text-sm font-semibold"
-      onClick={() => {
-        setMarkedForReview((currentValues) => ({
-          ...currentValues,
-          [currentFRQIndex]:
-            !(currentValues[currentFRQIndex] ?? false),
-        }));
-      }}
-    >
-      <Bookmark
-        size={24}
-        strokeWidth={2}
-        fill={
-          markedForReview[currentFRQIndex]
-            ? "currentColor"
-            : "none"
-        }
-        className={
-          markedForReview[currentFRQIndex]
-            ? "text-red-600"
-            : "text-black"
-        }
-      />
+                <button
+                  type="button"
+                  aria-pressed={markedForReview[currentFRQIndex] ?? false}
+                  className="flex h-full items-center gap-2 px-4 text-sm font-semibold"
+                  onClick={() => {
+                    setMarkedForReview((currentValues) => ({
+                      ...currentValues,
+                      [currentFRQIndex]: !(
+                        currentValues[currentFRQIndex] ?? false
+                      ),
+                    }));
+                  }}
+                >
+                  <Bookmark
+                    size={24}
+                    strokeWidth={2}
+                    fill={
+                      markedForReview[currentFRQIndex] ? "currentColor" : "none"
+                    }
+                    className={
+                      markedForReview[currentFRQIndex]
+                        ? "text-red-600"
+                        : "text-black"
+                    }
+                  />
 
-      <span>Mark for Review</span>
-    </button>
-  </div>
+                  <span>Mark for Review</span>
+                </button>
+              </div>
 
-  <div className="flex h-1 w-full gap-1">
-    <div className="flex-1 bg-blue-600" />
-    <div className="flex-1 bg-red-300" />
-    <div className="flex-1 bg-green-300" />
-    <div className="flex-1 bg-emerald-300" />
-    <div className="flex-1 bg-pink-300" />
-    <div className="flex-1 bg-purple-500" />
-    <div className="flex-1 bg-lime-300" />
-    <div className="flex-1 bg-cyan-500" />
-    <div className="flex-1 bg-indigo-400" />
-    <div className="flex-1 bg-fuchsia-500" />
-    <div className="flex-1 bg-teal-300" />
-    <div className="flex-1 bg-orange-500" />
-    <div className="flex-1 bg-red-500" />
-    <div className="flex-1 bg-sky-400" />
-    <div className="flex-1 bg-green-400" />
-  </div>
-</div>
+              <div className="flex h-1 w-full gap-1">
+                <div className="flex-1 bg-blue-600" />
+                <div className="flex-1 bg-red-300" />
+                <div className="flex-1 bg-green-300" />
+                <div className="flex-1 bg-emerald-300" />
+                <div className="flex-1 bg-pink-300" />
+                <div className="flex-1 bg-purple-500" />
+                <div className="flex-1 bg-lime-300" />
+                <div className="flex-1 bg-cyan-500" />
+                <div className="flex-1 bg-indigo-400" />
+                <div className="flex-1 bg-fuchsia-500" />
+                <div className="flex-1 bg-teal-300" />
+                <div className="flex-1 bg-orange-500" />
+                <div className="flex-1 bg-red-500" />
+                <div className="flex-1 bg-sky-400" />
+                <div className="flex-1 bg-green-400" />
+              </div>
+            </div>
 
             <p className="mb-4 font-sans text-sm">
               The <strong>{currentFRQ.title}</strong> can be used to theorize
@@ -599,39 +607,36 @@ const submissionModal = showSubmissionModal ? (
               <li>Explain how migration may influence population trends.</li>
             </ol>
 
-
-
             <div className="w-full max-w-[50rem]">
               <FRQResponseEditor
-  ariaLabel={`Response for FRQ ${currentFRQIndex + 1}`}
-  value={responses[currentFRQIndex] ?? ""}
-  onChange={(newResponse) => {
-    setResponses((currentResponses) => {
-      const updatedResponses = [...currentResponses];
-      updatedResponses[currentFRQIndex] = newResponse;
-      return updatedResponses;
-    });
-  }}
-/>
+                ariaLabel={`Response for FRQ ${currentFRQIndex + 1}`}
+                value={responses[currentFRQ.id] ?? ""}
+                onChange={(newResponse) => {
+                  setResponses((currentResponses) => {
+                    return {
+                      ...currentResponses,
+                      [currentFRQ.id]: newResponse,
+                    };
+                  });
+                }}
+              />
             </div>
           </section>
         </div>
 
-      <FRQFooter
-  testName="AP Human Geography Practice Exam 1"
-  currentFrqIndex={currentFRQIndex}
-  totalFrqs={questions.length}
-  onPrevious={() => {
-    setCurrentFRQIndex((currentIndex) =>
-      Math.max(currentIndex - 1, 0),
-    );
-  }}
-  onNext={handleNext}
-  onJumpToFrq={(index) => {
-    setCurrentFRQIndex(index);
-    setShowReviewPage(false);
-  }}
-/>
+        <FRQFooter
+          testName="AP Human Geography Practice Exam 1"
+          currentFrqIndex={currentFRQIndex}
+          totalFrqs={questions.length}
+          onPrevious={() => {
+            setCurrentFRQIndex((currentIndex) => Math.max(currentIndex - 1, 0));
+          }}
+          onNext={handleNext}
+          onJumpToFrq={(index) => {
+            setCurrentFRQIndex(index);
+            setShowReviewPage(false);
+          }}
+        />
       </section>
     </main>
   );

--- a/src/types/frq.ts
+++ b/src/types/frq.ts
@@ -1,5 +1,35 @@
 import type { Timestamp } from "firebase/firestore";
 
+/** An admin-authored prompt used by the digital FRQ testing experience. */
+export interface FRQTemplate {
+  id?: string;
+  subject?: string;
+  unitId?: string;
+  title?: string;
+  directions?: string;
+  questions?: Array<{ title?: string; prompt?: string }>;
+  createdAt?: Timestamp;
+  updatedAt?: Timestamp;
+}
+
+/** A completed digital-test response awaiting staff grading. */
+export interface GradableFRQSubmission {
+  id?: string;
+  templateId: string;
+  studentId: string;
+  responses: string[];
+  submittedAt: Timestamp;
+}
+
+/** The immutable grading result presented on a student's dashboard. */
+export interface GradedFRQSubmission extends GradableFRQSubmission {
+  score: string;
+  feedback: string;
+  graderId: string;
+  gradedAt: Timestamp;
+  sourceSubmissionId: string;
+}
+
 export interface FRQSubmission {
   id?: string;
   userId: string;

--- a/src/types/frq.ts
+++ b/src/types/frq.ts
@@ -7,9 +7,16 @@ export interface FRQTemplate {
   unitId?: string;
   title?: string;
   directions?: string;
-  questions?: Array<{ title?: string; prompt?: string }>;
+  questions?: FRQTemplateQuestion[];
   createdAt?: Timestamp;
   updatedAt?: Timestamp;
+}
+
+export interface FRQTemplateQuestion {
+  /** Stable template-local identifier; never derived from display order. */
+  id: string;
+  title: string;
+  prompt?: string;
 }
 
 /** A completed digital-test response awaiting staff grading. */
@@ -17,7 +24,8 @@ export interface GradableFRQSubmission {
   id?: string;
   templateId: string;
   studentId: string;
-  responses: string[];
+  /** Responses are keyed by a stable FRQTemplateQuestion.id. */
+  responses: Record<string, string>;
   submittedAt: Timestamp;
 }
 


### PR DESCRIPTION
# Description
Added a Firestore system for digital FRQs:
- Admin-authored prompts live in frqTemplates.
- Completed student responses enter gradableFrqSubmissions, linked to their template ID.
- Graders create gradedFrqSubmissions containing the score, feedback, grader ID, and original response data.

The FRQ testing and grading pages now use these collections, with rules and indexes supporting secure queue/dashboard queries. Template writes are admin-only; students can submit only their own work; graders/admins can create grades. Existing MCQ and peer-grading behavior was not changed.

Resolves #302 

# Pull request type
- [X] Backend Refactoring

# Checklist
- [x] I have performed a self-review of my own code
