### PR TITLE
Text alignment

### DIFF
--- a/src/components/article-creator/AlignmentTune.ts
+++ b/src/components/article-creator/AlignmentTune.ts
@@ -1,5 +1,9 @@
 import type { API, BlockAPI, BlockTune } from "@editorjs/editorjs";
-import { ALIGNMENT_VALUES, type AlignmentValue, sanitizeAlignment } from "./alignment";
+import {
+  ALIGNMENT_VALUES,
+  type AlignmentValue,
+  sanitizeAlignment,
+} from "./alignment";
 
 const ICONS: Record<AlignmentValue, string> = {
   left: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 12H3"/><path d="M17 18H3"/><path d="M21 6H3"/></svg>`,

--- a/src/components/article-creator/AlignmentTune.ts
+++ b/src/components/article-creator/AlignmentTune.ts
@@ -1,0 +1,53 @@
+import type { API, BlockAPI, BlockTune } from "@editorjs/editorjs";
+import { ALIGNMENT_VALUES, type AlignmentValue, sanitizeAlignment } from "./alignment";
+
+const ICONS: Record<AlignmentValue, string> = {
+  left: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 12H3"/><path d="M17 18H3"/><path d="M21 6H3"/></svg>`,
+  center: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 12H7"/><path d="M19 18H5"/><path d="M21 6H3"/></svg>`,
+  right: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12H9"/><path d="M21 18H7"/><path d="M21 6H3"/></svg>`,
+  justify: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12h18"/><path d="M3 18h18"/><path d="M3 6h18"/></svg>`,
+};
+
+const TITLES: Record<AlignmentValue, string> = {
+  left: "Align left",
+  center: "Align center",
+  right: "Align right",
+  justify: "Justify",
+};
+
+type AlignmentMenuItem = {
+  icon: string;
+  title: string;
+  isActive: boolean;
+  closeOnActivate: true;
+  onActivate: () => void;
+};
+
+export default class AlignmentTune implements BlockTune {
+  static isTune = true;
+
+  private readonly block: BlockAPI;
+  private alignment: AlignmentValue;
+
+  constructor({ block, data }: { api: API; block: BlockAPI; data: unknown }) {
+    this.block = block;
+    this.alignment = sanitizeAlignment(data) ?? "left";
+  }
+
+  render(): AlignmentMenuItem[] {
+    return ALIGNMENT_VALUES.map((value) => ({
+      icon: ICONS[value],
+      title: TITLES[value],
+      isActive: this.alignment === value,
+      closeOnActivate: true,
+      onActivate: () => {
+        this.alignment = value;
+        this.block.dispatchChange();
+      },
+    }));
+  }
+
+  save(): AlignmentValue {
+    return this.alignment;
+  }
+}

--- a/src/components/article-creator/ArticleCreator.tsx
+++ b/src/components/article-creator/ArticleCreator.tsx
@@ -15,6 +15,7 @@ import {
   processTable,
   revertTableObjectToArray,
 } from "./FetchArticleFunctions";
+import { sanitizeAlignment } from "./alignment";
 import { Blocker } from "@/app/admin/subject/navigation-block";
 import { Button } from "@/components/ui/button";
 import { usePathname } from "next/navigation";
@@ -171,6 +172,15 @@ function ArticleCreator({ className }: { className?: string }) {
         data.blocks.map(async (block) => {
           // because of .type, its inferable that block.data is of an questions, so you can assert .data.questions as QuestionFormat[]
           /* eslint-disable */
+          if (block.tunes && "alignment" in block.tunes) {
+            const alignment = sanitizeAlignment(block.tunes.alignment);
+            if (alignment && alignment !== "left") {
+              block.tunes.alignment = alignment;
+            } else {
+              delete block.tunes.alignment;
+            }
+          }
+
           if (block.type === "questionsAddCard") {
             const updatedQuestions = await processQuestions(
               block.data.questions as QuestionFormat[],

--- a/src/components/article-creator/Editor.tsx
+++ b/src/components/article-creator/Editor.tsx
@@ -20,6 +20,7 @@ import Underline from "@editorjs/underline";
 import MathTex from "editorjs-math";
 import Delimiter from "@editorjs/delimiter";
 import Alert from "editorjs-alert";
+import AlignmentTune from "./AlignmentTune";
 import { QuestionsAddCard } from "./custom_questions/QuestionsAddCard";
 import { ClipboardCopy, Upload } from "lucide-react";
 import {
@@ -150,6 +151,7 @@ export const EDITOR_TOOLS: EditorConfig["tools"] = {
     class: Header as unknown as ToolConstructable,
     shortcut: "CTRL+SHIFT+H",
     inlineToolbar: true,
+    tunes: ["alignment"],
     config: {
       placeholder: "Enter a Header",
       levels: [1, 2, 3],
@@ -161,6 +163,7 @@ export const EDITOR_TOOLS: EditorConfig["tools"] = {
     class: Paragraph as unknown as ToolConstructable,
     shortcut: "CTRL+SHIFT+P",
     inlineToolbar: true,
+    tunes: ["alignment"],
   },
 
   image: {
@@ -218,7 +221,12 @@ export const EDITOR_TOOLS: EditorConfig["tools"] = {
     class: List as unknown as ToolConstructable,
     inlineToolbar: true,
     shortcut: "CTRL+ALT+8",
+    tunes: ["alignment"],
     config: { defaultStyle: "unordered" },
+  },
+
+  alignment: {
+    class: AlignmentTune as unknown as ToolConstructable,
   },
 
   questionsAddCard: {

--- a/src/components/article-creator/Renderer.tsx
+++ b/src/components/article-creator/Renderer.tsx
@@ -11,6 +11,10 @@ import { QuestionsOutput } from "./custom_questions/QuestionInstance";
 import type { QuestionFormat } from "@/types/questions";
 import "@/styles/katexStyling.css";
 import styles from "./Renderer.module.css";
+import { sanitizeAlignment } from "./alignment";
+
+// Tool names the "alignment" BlockTune is registered on (see Editor.tsx).
+const ALIGNABLE_TYPES = new Set(["paragraph", "header", "list"]);
 
 export function decodeEntities(str: string): string {
   const txt = document.createElement("textarea");
@@ -117,7 +121,10 @@ const customParsers: Record<
       caption: string;
       text: string;
     };
-    return `<blockquote>
+    // Quote's own native settings only ever offer left/center (see
+    // @editorjs/quote's renderSettings), so only "center" needs a style.
+    const style = alignment === "center" ? ' style="text-align:center"' : "";
+    return `<blockquote${style}>
       <p class="mb-3">${text}</p>
       <cite>${caption}</cite>
     </blockquote>`;
@@ -349,8 +356,21 @@ const Renderer = (props: { content: OutputData }) => {
   if (!props.content) return null;
 
   const parser = new edjsParser(undefined, customParsers);
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-  const markup = parser.parse(props.content);
+  const markup = props.content.blocks
+    .map((block) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      const blockMarkup = parser.parseBlock(block);
+      if (blockMarkup instanceof Error) return "";
+
+      const alignment = ALIGNABLE_TYPES.has(block.type)
+        ? sanitizeAlignment(block.tunes?.alignment)
+        : undefined;
+
+      return alignment && alignment !== "left"
+        ? `<div style="text-align:${alignment}">${blockMarkup}</div>`
+        : blockMarkup;
+    })
+    .join("");
 
   return (
     <article

--- a/src/components/article-creator/alignment.ts
+++ b/src/components/article-creator/alignment.ts
@@ -1,0 +1,13 @@
+// Single source of truth for what a block's alignment tune is allowed to
+// contain. Anything read from Firestore, an imported/pasted JSON blob, or
+// user input is checked against this list before it's ever trusted.
+export const ALIGNMENT_VALUES = ["left", "center", "right", "justify"] as const;
+
+export type AlignmentValue = (typeof ALIGNMENT_VALUES)[number];
+
+export function sanitizeAlignment(value: unknown): AlignmentValue | undefined {
+  return typeof value === "string" &&
+    (ALIGNMENT_VALUES as readonly string[]).includes(value)
+    ? (value as AlignmentValue)
+    : undefined;
+}

--- a/src/components/article-creator/editorjs-render.ts
+++ b/src/components/article-creator/editorjs-render.ts
@@ -9,6 +9,10 @@ import "@/styles/highlightjs.css";
 import type { QuestionFormat } from "@/types/questions";
 import "@/styles/katexStyling.css";
 import styles from "./Renderer.module.css";
+import { sanitizeAlignment } from "./alignment";
+
+// Tool names the "alignment" BlockTune is registered on (see Editor.tsx).
+const ALIGNABLE_TYPES = new Set(["paragraph", "header", "list"]);
 
 // DOM-free entity decoder so this module can run during server rendering.
 // Previously this used `document.createElement("textarea")`, which kept the
@@ -117,7 +121,10 @@ const customParsers: Record<
       caption: string;
       text: string;
     };
-    return `<blockquote>
+    // Quote's own native settings only ever offer left/center (see
+    // @editorjs/quote's renderSettings), so only "center" needs a style.
+    const style = alignment === "center" ? ' style="text-align:center"' : "";
+    return `<blockquote${style}>
       <p class="mb-3">${text}</p>
       <cite>${caption}</cite>
     </blockquote>`;
@@ -258,6 +265,20 @@ const customParsers: Record<
  */
 export function renderEditorJsToHtml(content: OutputData): string {
   const parser = new edjsParser(undefined, customParsers);
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-  return parser.parse(content);
+
+  return content.blocks
+    .map((block) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      const blockMarkup = parser.parseBlock(block);
+      if (blockMarkup instanceof Error) return "";
+
+      const alignment = ALIGNABLE_TYPES.has(block.type)
+        ? sanitizeAlignment(block.tunes?.alignment)
+        : undefined;
+
+      return alignment && alignment !== "left"
+        ? `<div style="text-align:${alignment}">${blockMarkup}</div>`
+        : blockMarkup;
+    })
+    .join("");
 }


### PR DESCRIPTION
# Description
Closes #330 

Registers a custom EditorJS `BlockTune` ("alignment") on paragraph, header, and list blocks, exposing left/center/right/justify options through the editor's native block-settings menu. Alignment is stored in the block's own `tunes` field, persists through save/reload, and renders consistently in both the live preview and published chapter pages via a shared, allowlist-based sanitizer. Also fixes Quote's existing (previously dead) native alignment so it actually renders.

Why a BlockTune specifically: EditorJS's Tunes are its own native mechanism for per-block settings (the same menu that already has "Delete image", "Move up/down", etc.), so this gets keyboard navigation, focus handling, and accessible labels for free from the framework itself, per the issue's own requirement to use the editor's native alignment extension rather than a custom-built toolbar.

# Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


# Demo
<img width="1224" height="627" alt="screenshot-1785447036332-0" src="https://github.com/user-attachments/assets/c6b50a64-bc3c-4777-87ad-f8641c626f27" />

# How Has This Been Tested? How can the reviewer test it?
Automated checks (all clean):

npx tsc --noEmit

next lint (scoped to changed files – only 2 pre-existing, unrelated warnings)

npm run build (all 21 routes compile, including the admin editor page and the public chapter SSR page)

Manual testing, done against a local editor instance seeded with paragraph/header/List/quote blocks:

Each of paragraph, header, and List shows “Align Left / Align center / Align right / Justify” in its settings menu (in addition to that block’s own existing settings), with the currently-active option highlighted.

Clicking an option updates the live preview immediately and writes tunes.alignment into the block’s saved JSON.

Two different blocks (e.g. a centered header and a right-aligned paragraph) hold their alignments independently – changing one does not reset the other.

A block with no tunes field at all (simulating an existing pre-feature article) renders identically to one explicitly set to “left” – no extra markup, left-aligned by default.

Hand-crafting a block with tunes.alignment: "expression(alert(1))" via the editor’s existing “paste raw JSON” debug feature renders with no style attribute at all – the sanitizer silently drops it rather than emitting the malicious value.

Quote’s own native alignment (left/center), previously computed but never applied to the output markup, now actually renders text-align:center.

To test manually: open the article editor, click into a paragraph/heading/List item, open its block settings (the “::” handle), pick an alignment, and confirm the live preview updates and the choice survives a save/reload.

# Checklist

- [x] I have performed a self-review of my own code
