### PR TITLE
Add FRQ tests to admin subject editor

### DIFF
--- a/src/app/admin/subject/[slug]/[unit]/frq/[id]/page.tsx
+++ b/src/app/admin/subject/[slug]/[unit]/frq/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import FRQEditorRenderer from "@/components/frq/editorRenderer";
 import { db } from "@/lib/firebase";
+import type { FRQTemplate } from "@/types/frq";
 import { doc, getDoc } from "firebase/firestore";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -14,30 +15,63 @@ const Page = () => {
   const unitId = pathParts[1] ?? "";
   const frqId = pathParts[3] ?? "";
 
-  const [frqFound, setFrqFound] = useState<boolean | null>(null);
+  const [frqTemplate, setFrqTemplate] = useState<FRQTemplate | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [frqFound, setFrqFound] = useState(false);
 
   useEffect(() => {
     if (!subject || !unitId || !frqId) {
       setFrqFound(false);
+      setIsLoading(false);
       return;
     }
 
-    (async () => {
-      const docRef = doc(db, "frqTemplates", frqId);
+    const loadFrq = async () => {
+      try {
+        const docRef = doc(db, "frqTemplates", frqId);
+        const docSnap = await getDoc(docRef);
 
-      const docSnap = await getDoc(docRef);
-      setFrqFound(docSnap.exists());
-    })().catch((error) => {
-      console.error("Error fetching FRQ:", error);
-      setFrqFound(false);
-    });
+        if (!docSnap.exists()) {
+          setFrqFound(false);
+          return;
+        }
+
+        const loadedFrq: FRQTemplate = {
+          id: docSnap.id,
+          ...(docSnap.data() as Omit<FRQTemplate, "id">),
+        };
+
+        const belongsToRoute =
+          loadedFrq.subject === subject &&
+          loadedFrq.unitId === unitId;
+
+        if (!belongsToRoute) {
+          setFrqFound(false);
+          return;
+        }
+
+        setFrqTemplate(loadedFrq);
+        setFrqFound(true);
+      } catch {
+        setFrqFound(false);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void loadFrq();
   }, [subject, unitId, frqId]);
 
-  if (frqFound === null) {
+  if (isLoading) {
     return <div>Loading...</div>;
   }
 
-  return <FRQEditorRenderer frqFound={frqFound} />;
+  return (
+    <FRQEditorRenderer
+      frqFound={frqFound}
+      frqTemplate={frqTemplate}
+    />
+  );
 };
 
 export default Page;

--- a/src/app/admin/subject/[slug]/_components/unit.tsx
+++ b/src/app/admin/subject/[slug]/_components/unit.tsx
@@ -12,8 +12,10 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { Unit, Chapter, UnitTest } from "@/types/firestore";
+import type { FRQTemplate } from "@/types/frq";
 import short from "short-uuid";
 import UnitTests from "./unitTests";
+import UnitFrqs from "./unitFrqs";
 import ChapterContent from "./chapterContent";
 import { Input } from "@/components/ui/input";
 import { useAutoAnimate } from "@formkit/auto-animate/react";
@@ -36,6 +38,14 @@ interface UnitComponentProps {
   subjectSlug: string;
   subjectTitle: string;
   hasUnit0?: boolean;
+  frqTemplates: FRQTemplate[];
+  onFrqAdd: (unitId: string, title: string) => Promise<void>;
+  onFrqRename: (frqId: string, title: string) => Promise<void>;
+  onFrqVisibilityChange: (
+    frqId: string,
+    isPublic: boolean,
+  ) => Promise<void>;
+  onFrqDelete: (frqId: string) => Promise<void>;
 }
 
 /**
@@ -52,6 +62,11 @@ function UnitComponent({
   subjectSlug,
   subjectTitle,
   hasUnit0,
+  frqTemplates,
+  onFrqAdd,
+  onFrqRename,
+  onFrqVisibilityChange,
+  onFrqDelete,
 }: UnitComponentProps) {
   const [expanded, setExpanded] = useState<boolean>(false);
 
@@ -405,6 +420,16 @@ function UnitComponent({
             setTestVisibility={setTestVisibility}
             moveTestUp={moveTestUp}
             moveTestDown={moveTestDown}
+          />
+          <h3 className="mb-1 mt-6 text-xl font-semibold">FRQs</h3>
+          <UnitFrqs
+            unitId={unit.id}
+            subjectSlug={subjectSlug}
+            frqs={frqTemplates}
+            onFrqAdd={(title) => onFrqAdd(unit.id, title)}
+            onFrqUpdate={onFrqRename}
+            onFrqDelete={onFrqDelete}
+            onFrqVisibilityChange={onFrqVisibilityChange}
           />
         </div>
       )}

--- a/src/app/admin/subject/[slug]/_components/unitFrqs.tsx
+++ b/src/app/admin/subject/[slug]/_components/unitFrqs.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { memo, useState } from "react";
+import { Plus, Trash2 } from "lucide-react";
+import { Link } from "../../link";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { FRQTemplate } from "@/types/frq";
+
+type UnitFrqsProps = {
+  unitId: string;
+  subjectSlug: string;
+  frqs: FRQTemplate[];
+  onFrqAdd: (title: string) => void;
+  onFrqUpdate: (frqId: string, title: string) => void;
+  onFrqDelete: (frqId: string) => void;
+  onFrqVisibilityChange: (frqId: string, isPublic: boolean) => void;
+};
+
+function UnitFrqs({
+  unitId,
+  subjectSlug,
+  frqs,
+  onFrqAdd,
+  onFrqUpdate,
+  onFrqDelete,
+  onFrqVisibilityChange,
+}: UnitFrqsProps) {
+  const [newFrqTitle, setNewFrqTitle] = useState("");
+
+  const handleAddFrq = () => {
+    const title = newFrqTitle.trim();
+
+    if (!title) {
+      return;
+    }
+
+    onFrqAdd(title);
+    setNewFrqTitle("");
+  };
+
+  const handleRenameFrq = (frqId: string, currentTitle: string) => {
+    const updatedTitle = window.prompt("Enter new FRQ name", currentTitle)?.trim();
+
+    if (updatedTitle) {
+      onFrqUpdate(frqId, updatedTitle);
+    }
+  };
+
+  return (
+    <div>
+      {frqs.map((frq, index) => {
+        if (!frq.id) {
+          return null;
+        }
+
+        return (
+          <div
+            key={frq.id}
+            className="mb-3 flex items-center justify-between gap-2 rounded-sm ring-gray-300 ring-offset-2 transition-[box-shadow] hover:ring-2"
+          >
+            <div className="grid">
+              <label htmlFor={`frq-visibility-${frq.id}`}>Public</label>
+              <input
+                id={`frq-visibility-${frq.id}`}
+                type="checkbox"
+                checked={frq.isPublic ?? false}
+                onChange={(event) =>
+                  onFrqVisibilityChange(frq.id!, event.target.checked)
+                }
+              />
+            </div>
+
+            <Link
+              className="whitespace-nowrap rounded-full border border-input bg-background px-4 py-2 text-sm font-medium ring-offset-background transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              href={`/admin/subject/${subjectSlug}/${unitId}/frq/${frq.id}`}
+            >
+              Edit FRQ {index + 1}
+            </Link>
+
+            <p
+              onDoubleClick={() =>
+                handleRenameFrq(frq.id!, frq.title || "Untitled FRQ")
+              }
+              className="w-full cursor-pointer rounded-sm p-1.5 leading-none hover:bg-accent"
+            >
+              {frq.title || "Untitled FRQ"}
+            </p>
+
+            <Button
+              type="button"
+              className="ml-auto mr-1 aspect-square rounded-md p-0"
+              variant="destructive"
+              onClick={() => onFrqDelete(frq.id!)}
+            >
+              <Trash2 />
+            </Button>
+          </div>
+        );
+      })}
+
+      <div className="mt-4 flex gap-2">
+        <Input
+          value={newFrqTitle}
+          onChange={(event) => setNewFrqTitle(event.target.value)}
+          placeholder="New FRQ name"
+          className="w-1/2"
+        />
+
+        <Button
+          type="button"
+          onClick={handleAddFrq}
+          className="bg-green-500 hover:bg-green-600"
+          disabled={!newFrqTitle.trim()}
+        >
+          <Plus className="-ml-1 mr-2" />
+          Add FRQ
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default memo(UnitFrqs);

--- a/src/app/admin/subject/[slug]/page.tsx
+++ b/src/app/admin/subject/[slug]/page.tsx
@@ -5,11 +5,18 @@ import { Link } from "@/app/admin/subject/link";
 import { ArrowLeft, Save, Plus } from "lucide-react";
 import { useUser } from "@/components/hooks/UserContext";
 import { db } from "@/lib/firebase";
+import type { FRQTemplate } from "@/types/frq";
 import {
   collection,
+  deleteDoc,
   doc,
   getDoc,
   getDocs,
+  query,
+  serverTimestamp,
+  setDoc,
+  updateDoc,
+  where,
   writeBatch,
 } from "firebase/firestore";
 import { Button, buttonVariants } from "@/components/ui/button";
@@ -69,6 +76,7 @@ export default function Page({ params }: { params: { slug: string } }) {
   const { user, error, setError, setLoading } = useUser();
   const [subjectTitle, setSubjectTitle] = useState<string>("");
   const [units, setUnits] = useState<Unit[]>([]);
+  const [frqTemplates, setFrqTemplates] = useState<FRQTemplate[]>([]);
   const [hasUnit0, setHasUnit0] = useState<boolean>(false);
   const [resetting, setResetting] = useState<boolean>(false);
 
@@ -84,6 +92,20 @@ export default function Page({ params }: { params: { slug: string } }) {
         if (user && (user.access === "admin" || user.access === "member")) {
           const docRef = doc(db, "subjects", params.slug);
           const docSnap = await getDoc(docRef);
+          const frqQuery = query(
+            collection(db, "frqTemplates"),
+            where("subject", "==", params.slug),
+          );
+          
+          const frqSnapshot = await getDocs(frqQuery);
+          
+          const loadedFrqs: FRQTemplate[] = frqSnapshot.docs.map((frqDoc) => ({
+            id: frqDoc.id,
+            ...(frqDoc.data() as Omit<FRQTemplate, "id">),
+          }));
+          
+          setFrqTemplates(loadedFrqs);
+
           if (docSnap.exists()) {
             // We have an existing subject
             const fetched = docSnap.data() as Subject;
@@ -169,7 +191,121 @@ export default function Page({ params }: { params: { slug: string } }) {
     setUnits((prev) => prev.map((u) => (u.id === unitId ? updatedUnit : u)));
     setUnsavedChanges(true);
   };
+  
+  /****************************************************
+   *                   FRQ ACTIONS
+   ****************************************************/
+  
+  const handleAddFrq = async (unitId: string, title: string) => {
+    const trimmedTitle = title.trim();
+  
+    if (!trimmedTitle) {
+      return;
+    }
+  
+    const frqId = generateShortId();
+  
+    const newFrq: FRQTemplate = {
+      id: frqId,
+      subject: params.slug,
+      unitId,
+      title: trimmedTitle,
+      directions: "",
+      questions: [],
+      isPublic: false,
+    };
+  
+    try {
+      await setDoc(doc(db, "frqTemplates", frqId), {
+        subject: newFrq.subject,
+        unitId: newFrq.unitId,
+        title: newFrq.title,
+        directions: newFrq.directions,
+        questions: newFrq.questions,
+        isPublic: newFrq.isPublic,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      });
+  
+      setFrqTemplates((currentFrqs) => [...currentFrqs, newFrq]);
+      setUnsavedChanges(true);
+    } catch {
+      alert("Unable to add the FRQ. Please try again.");
+    }
+  };
+  
+  const handleRenameFrq = async (frqId: string, title: string) => {
+    const trimmedTitle = title.trim();
+  
+    if (!trimmedTitle) {
+      return;
+    }
+  
+    try {
+      await updateDoc(doc(db, "frqTemplates", frqId), {
+        title: trimmedTitle,
+        updatedAt: serverTimestamp(),
+      });
+  
+      setFrqTemplates((currentFrqs) =>
+        currentFrqs.map((frq) =>
+          frq.id === frqId ? { ...frq, title: trimmedTitle } : frq,
+        ),
+      );
 
+      setUnsavedChanges(true);
+
+    } catch {
+      alert("Unable to rename the FRQ. Please try again.");
+    }
+  };
+  
+  const handleFrqVisibilityChange = async (
+    frqId: string,
+    isPublic: boolean,
+  ) => {
+    try {
+      await updateDoc(doc(db, "frqTemplates", frqId), {
+        isPublic,
+        updatedAt: serverTimestamp(),
+      });
+  
+      setFrqTemplates((currentFrqs) =>
+        currentFrqs.map((frq) =>
+          frq.id === frqId ? { ...frq, isPublic } : frq,
+        ),
+      );
+
+      setUnsavedChanges(true);
+
+    } catch {
+      alert("Unable to update the FRQ visibility. Please try again.");
+    }
+  };
+  
+  const handleDeleteFrq = async (frqId: string) => {
+    const confirmed = window.confirm(
+      "Delete this FRQ? This action cannot be undone.",
+    );
+  
+    if (!confirmed) {
+      return;
+    }
+  
+    try {
+      await deleteDoc(doc(db, "frqTemplates", frqId));
+  
+      setFrqTemplates((currentFrqs) =>
+        currentFrqs.filter((frq) => frq.id !== frqId),
+      );
+
+      setUnsavedChanges(true);
+      
+    } catch {
+      alert("Unable to delete the FRQ. Please try again.");
+    }
+  };
+  
   /****************************************************
    *                   SAVE ACTION
    * This function will force delete anything in the db that isnt in the local to keep db clean
@@ -483,7 +619,7 @@ export default function Page({ params }: { params: { slug: string } }) {
 
           {/* Render each Unit */}
           <div className="my-4 space-y-4">
-            {units.map((unit, index) => (
+          {units.map((unit, index) => (
             <UnitComponent
               key={unit.id}
               unit={unit}
@@ -495,6 +631,13 @@ export default function Page({ params }: { params: { slug: string } }) {
               onMoveDown={handleMoveUnitDown}
               subjectSlug={params.slug}
               hasUnit0={hasUnit0}
+              frqTemplates={frqTemplates.filter(
+                (frq) => frq.unitId === unit.id,
+              )}
+              onFrqAdd={handleAddFrq}
+              onFrqRename={handleRenameFrq}
+              onFrqVisibilityChange={handleFrqVisibilityChange}
+              onFrqDelete={handleDeleteFrq}
             />
           ))}
           </div>

--- a/src/components/frq/editorRenderer.tsx
+++ b/src/components/frq/editorRenderer.tsx
@@ -20,6 +20,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import type { QuestionFormat, QuestionInput } from "@/types/questions";
 import { Clock3, Eye, Info, Plus, Save, Trash2 } from "lucide-react";
+import type { FRQTemplate } from "@/types/frq";
 import { useMemo, useState } from "react";
 
 type QuestionStatus = "public" | "legacy";
@@ -49,6 +50,7 @@ interface EditorFRQ {
 
 interface FRQEditorRendererProps {
   frqFound: boolean;
+  frqTemplate: FRQTemplate | null;
 }
 
 const createQuestionInput = (value = ""): QuestionInput => ({
@@ -93,32 +95,6 @@ const createDescriptionQuestion = (
   topic: "",
 });
 
-const createEditorQuestion = (
-  id: string,
-  prompt: string,
-  points: number,
-): EditorQuestion => ({
-  id,
-  status: "public",
-  inputType: "text",
-  criteria: [
-    {
-      id: `${id}-criterion-1`,
-      description: "",
-      points,
-    },
-  ],
-  questionData: {
-    question: createQuestionInput(prompt),
-    type: "frq",
-    options: [],
-    answers: [],
-    explanation: createQuestionInput(),
-    content: createQuestionInput(),
-    topic: "",
-  },
-});
-
 /**
  * AP-style subquestion label: 1a, 1b, 1c. Past 26 questions it rolls over to
  * two letters (1aa, 1ab) rather than walking off the end of the alphabet into
@@ -136,83 +112,22 @@ const getSubquestionLabel = (frqIndex: number, questionIndex: number) => {
   return `${frqIndex + 1}${label}`;
 };
 
-const mockFRQs: EditorFRQ[] = [
-  {
-    id: "frq-1",
-    title: "FRQ 1",
-    description: createQuestionInput(
-      "Read the source material carefully. Then answer all parts of the question using evidence from the source.",
-    ),
-    questions: [
-      createEditorQuestion(
-        "frq-1-a",
-        "Identify one claim made in the source.",
-        1,
-      ),
-      createEditorQuestion(
-        "frq-1-b",
-        "Explain how evidence from the source supports that claim.",
-        2,
-      ),
-      createEditorQuestion(
-        "frq-1-c",
-        "Evaluate one limitation of the source's argument.",
-        2,
-      ),
-    ],
-  },
-  {
-    id: "frq-2",
-    title: "FRQ 2",
-    description: createQuestionInput(
-      "Examine the provided information and respond to each part of the question.",
-    ),
-    questions: [
-      createEditorQuestion(
-        "frq-2-a",
-        "Describe the main process shown in the provided material.",
-        1,
-      ),
-      createEditorQuestion(
-        "frq-2-b",
-        "Explain one relationship between two parts of the process.",
-        2,
-      ),
-      createEditorQuestion(
-        "frq-2-c",
-        "Use evidence from the material to justify your response.",
-        2,
-      ),
-    ],
-  },
-  {
-    id: "frq-3",
-    title: "FRQ 3",
-    description: createQuestionInput(
-      "Use the information provided to develop and support a defensible response.",
-    ),
-    questions: [
-      createEditorQuestion(
-        "frq-3-a",
-        "State a defensible conclusion based on the information provided.",
-        1,
-      ),
-      createEditorQuestion(
-        "frq-3-b",
-        "Support your conclusion with two relevant pieces of evidence.",
-        2,
-      ),
-      createEditorQuestion(
-        "frq-3-c",
-        "Explain how one piece of evidence could be interpreted differently.",
-        2,
-      ),
-    ],
-  },
-];
+const createEditorFrqFromTemplate = (
+  template: FRQTemplate,
+): EditorFRQ => ({
+  id: template.id ?? makeId("frq"),
+  title: template.title?.trim() || "Untitled FRQ",
+  description: createQuestionInput(template.directions ?? ""),
+  questions: [],
+});
 
-const FRQEditorRenderer = ({ frqFound }: FRQEditorRendererProps) => {
-  const [frqs, setFrqs] = useState<EditorFRQ[]>(mockFRQs);
+const FRQEditorRenderer = ({
+  frqFound,
+  frqTemplate,
+}: FRQEditorRendererProps) => {
+  const [frqs, setFrqs] = useState<EditorFRQ[]>(() =>
+    frqTemplate ? [createEditorFrqFromTemplate(frqTemplate)] : [],
+  );
   const [currentFrqIndex, setCurrentFrqIndex] = useState(0);
   const [batchName, setBatchName] = useState("FRQ Batch");
   const [batchVisibility, setBatchVisibility] =

--- a/src/types/frq.ts
+++ b/src/types/frq.ts
@@ -3,11 +3,12 @@ import type { Timestamp } from "firebase/firestore";
 /** An admin-authored prompt used by the digital FRQ testing experience. */
 export interface FRQTemplate {
   id?: string;
-  subject?: string;
-  unitId?: string;
-  title?: string;
-  directions?: string;
-  questions?: FRQTemplateQuestion[];
+  subject: string;
+  unitId: string;
+  title: string;
+  directions: string;
+  questions: FRQTemplateQuestion[];
+  isPublic?: boolean;
   createdAt?: Timestamp;
   updatedAt?: Timestamp;
 }


### PR DESCRIPTION
# Description

Adds FRQ support to the admin subject editor pages.

FRQs are now loaded from Firestore based on the subject slug in the URL and displayed under the correct unit alongside the existing tests.

This change also adds support for:

- Creating new FRQs
- Renaming FRQs
- Updating public/private status
- Deleting FRQs
- Navigating to the correct FRQ editor route
- Loading the selected FRQ’s actual Firestore data in the editor instead of mock data

The FRQ editor’s existing Add Question and Save Changes functionality remains disabled and is outside the scope of this change.

# Pull request type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

# Demo


<img width="1280" height="832" alt="demo1" src="https://github.com/user-attachments/assets/51c5797a-e347-48c1-a8a5-640d12b2531d" />


<img width="1280" height="832" alt="demo2" src="https://github.com/user-attachments/assets/44b16768-5eab-43b1-b1ea-5d862d8dc517" />

# How Has This Been Tested? How can the reviewer test it?

1. Pull down the feature branch.
2. Start the Firebase emulators and the local Next.js application.
3. Sign in with an admin user.
4. Navigate to an admin subject page, such as:
   `/admin/subject/calculus-ab`
5. Expand a unit.
6. Confirm the FRQ section appears below the Tests section.
7. Enter an FRQ name and click Add FRQ.
8. Click Save Changes.
9. Refresh the page and confirm the FRQ remains under the correct unit.
10. Double-click the FRQ title, rename it, and confirm the updated title persists.
11. Toggle the Public checkbox and confirm the status persists.
12. Click Edit FRQ.
13. Confirm the URL contains the correct subject slug, unit ID, and FRQ ID.
14. Confirm the FRQ editor displays the selected FRQ’s actual title instead of the previous mock FRQ data.
15. Delete the FRQ and confirm it is removed.

Additional validation completed:

- `npx tsc --noEmit`
- `npm run lint`

Lint completed with existing project warnings and no blocking errors.

# Checklist

- [x] I have performed a self-review of my own code
