### PR TITLE
Fix feedback create permissions and move GitHub issue creation server-side

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -106,11 +106,17 @@ service cloud.firestore {
       allow get: if isMemberOrAdmin();
 
       // Anyone (including anonymous visitors) can submit feedback
-      allow create: if request.resource.data.type in ['general', 'bug', 'feature']
+      allow create: if request.resource.data.keys().hasAll(['type', 'title', 'message', 'email', 'createdAt'])
+                    && request.resource.data.keys().hasOnly(['type', 'title', 'message', 'email', 'createdAt', 'bugType', 'bugUrl', 'attachedImage', 'featureProblem', 'featureAlternatives', 'featureSolution', 'featureContextUrl'])
+                    && !('isResolved' in request.resource.data)
+                    && request.resource.data.type in ['general', 'bug', 'feature']
                     && request.resource.data.title is string
                     && request.resource.data.title.trim() != ''
                     && request.resource.data.message is string
-                    && request.resource.data.message.trim() != '';
+                    && request.resource.data.message.trim() != ''
+                    && request.resource.data.email is string
+                    && request.resource.data.createdAt is timestamp
+                    && request.resource.data.createdAt <= request.time;
 
       allow update, delete: if isMemberOrAdmin();
     }

--- a/firestore.rules
+++ b/firestore.rules
@@ -101,9 +101,17 @@ service cloud.firestore {
     }
 
     match /feedback/{feedbackId} {
-      allow read: if isMemberOrAdmin;
-      allow list: if isMemberOrAdmin;
+      allow read: if isMemberOrAdmin();
+      allow list: if isMemberOrAdmin();
       allow get: if isMemberOrAdmin();
+
+      // Anyone (including anonymous visitors) can submit feedback
+      allow create: if request.resource.data.type in ['general', 'bug', 'feature']
+                    && request.resource.data.title is string
+                    && request.resource.data.title.trim() != ''
+                    && request.resource.data.message is string
+                    && request.resource.data.message.trim() != '';
+
       allow update, delete: if isMemberOrAdmin();
     }
   }

--- a/src/app/admin/feedback/[slug]/FeedbackDetailsClient.tsx
+++ b/src/app/admin/feedback/[slug]/FeedbackDetailsClient.tsx
@@ -3,18 +3,13 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { db } from '@/lib/firebase';
-import { doc, getDoc, updateDoc, setDoc } from 'firebase/firestore';
+import { auth, db } from '@/lib/firebase';
+import { doc, getDoc } from 'firebase/firestore';
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 
 interface FeedbackDetailsClientProps {
   slug: string;
-  config: {
-    gitHubAccessToken: string;
-    gitHubRepoOwner: string;
-    gitHubRepoName: string;
-  };
 }
 
 function parseMarkdown(text: string): string {
@@ -43,7 +38,7 @@ interface FeedbackItem {
   featureContextUrl?: string;
 }
 
-export default function FeedbackDetailsClient({ slug, config }: FeedbackDetailsClientProps) {
+export default function FeedbackDetailsClient({ slug }: FeedbackDetailsClientProps) {
   const router = useRouter();
   const [bug, setBug] = useState<FeedbackItem | null>(null);
   const [loading, setLoading] = useState(true);
@@ -75,63 +70,28 @@ export default function FeedbackDetailsClient({ slug, config }: FeedbackDetailsC
 
   const handleCreateGitHubIssue = async () => {
     if (!bug) return;
-    if (!config.gitHubAccessToken || !config.gitHubRepoOwner || !config.gitHubRepoName) {
-      alert("GitHub integration is not fully configured. Please check your server environment variables.");
-      return;
-    }
 
     setIsCreatingIssue(true);
 
     try {
-      const owner = config.gitHubRepoOwner;
-      const repo = config.gitHubRepoName;
-      const url = `https://api.github.com/repos/${owner}/${repo}/issues`;
-
-      const imgMarkdown = bug.attachedImage && bug.attachedImage.startsWith('http') ? `\n\n[Attached Image](${bug.attachedImage})` : '';
-
-      let issueBody = `### Feedback Context\n\n- **Type:** ${bug.type}\n- **Contact Email:** ${bug.email ?? 'anonymous'}\n`;
-      if (bug.bugUrl && bug.bugUrl !== 'N/A') {
-        issueBody += `- **Context URL:** ${bug.bugUrl}\n`;
-      }
-      if (bug.type === 'bug') {
-        issueBody += `- **Category:** ${bug.bugType ?? 'N/A'}\n`;
-        issueBody += `\n### Detailed Description & Steps to Reproduce\n\n${bug.message}\n${imgMarkdown}`;
-      } else if (bug.type === 'feature') {
-        issueBody += `\n### Feature Request Details\n`;
-        if (bug.featureProblem) issueBody += `- **Problem:** ${bug.featureProblem}\n`;
-        if (bug.featureAlternatives) issueBody += `- **Alternatives Considered:** ${bug.featureAlternatives}\n`;
-        if (bug.featureSolution) issueBody += `- **Proposed Solution:** ${bug.featureSolution}\n`;
-        issueBody += `\n### Additional Description\n\n${bug.message}\n${imgMarkdown}`;
-      } else {
-        issueBody += `\n### Description\n\n${bug.message}${imgMarkdown}`;
+      const idToken = await auth.currentUser?.getIdToken();
+      if (!idToken) {
+        throw new Error('You must be signed in to do this.');
       }
 
-      const title = bug.title && bug.title.trim().length > 0 ? bug.title : `${bug.type === 'bug' ? 'Bug' : 'Feature'}: ${bug.bugType || ''}`;
-      const payload = {
-        title,
-        body: issueBody.trim(),
-        labels: [bug.type === 'bug' ? 'bug' : 'enhancement'],
-      };
-      console.log('Creating GitHub issue with payload:', payload);
-      const response = await fetch(url, {
+      const response = await fetch('/api/feedback/create-issue', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${config.gitHubAccessToken}`,
-          'Accept': 'application/vnd.github.v3+json',
+          'Authorization': `Bearer ${idToken}`,
         },
-        body: JSON.stringify(payload),
+        body: JSON.stringify({ feedbackId: slug }),
       });
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({})) as any;
-        const detailed = errorData.errors?.map((e: any) => `${e.resource || ''} ${e.field || ''} ${e.code || ''}`).join(', ');
-        const msg = errorData.message ?? `GitHub API responded with status ${response.status}`;
-        throw new Error(detailed ? `${msg}: ${detailed}` : msg);
-      }
 
-      // Update Firestore document resolution status to resolved
-      const docRef = doc(db, 'feedback', slug);
-      await setDoc(docRef, { isResolved: true }, { merge: true });
+      const result = await response.json().catch(() => ({})) as { error?: string };
+      if (!response.ok) {
+        throw new Error(result.error ?? `Request failed with status ${response.status}`);
+      }
 
       alert("GitHub Issue created successfully!");
       setSubmitted(true);

--- a/src/app/admin/feedback/[slug]/page.tsx
+++ b/src/app/admin/feedback/[slug]/page.tsx
@@ -7,11 +7,5 @@ interface PageProps {
 }
 
 export default function FeedbackDetailsPage({ params }: PageProps) {
-  const config = {
-    gitHubAccessToken: process.env.GITHUB_ACCESS_TOKEN ?? '',
-    gitHubRepoOwner: process.env.GITHUB_REPO_OWNER ?? '',
-    gitHubRepoName: process.env.GITHUB_REPO_NAME ?? '',
-  };
-
-  return <FeedbackDetailsClient slug={params.slug} config={config} />;
+  return <FeedbackDetailsClient slug={params.slug} />;
 }

--- a/src/app/api/feedback/create-issue/route.ts
+++ b/src/app/api/feedback/create-issue/route.ts
@@ -1,0 +1,128 @@
+import { NextResponse, type NextRequest } from 'next/server';
+
+const PROJECT_ID = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
+
+interface FirestoreValue {
+  stringValue?: string;
+  booleanValue?: boolean;
+}
+
+interface FirestoreDocument {
+  fields?: Record<string, FirestoreValue>;
+}
+
+function parseFirestoreFields(doc: FirestoreDocument): Record<string, string | boolean> {
+  const result: Record<string, string | boolean> = {};
+  for (const [key, value] of Object.entries(doc.fields ?? {})) {
+    if (value.stringValue !== undefined) result[key] = value.stringValue;
+    else if (value.booleanValue !== undefined) result[key] = value.booleanValue;
+  }
+  return result;
+}
+
+export async function POST(req: NextRequest) {
+  const authHeader = req.headers.get('authorization');
+  const idToken = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  if (!idToken) {
+    return NextResponse.json({ error: 'Missing authorization token' }, { status: 401 });
+  }
+
+  const body = (await req.json().catch(() => null)) as { feedbackId?: string } | null;
+  const feedbackId = body?.feedbackId;
+  if (!feedbackId) {
+    return NextResponse.json({ error: 'Missing feedbackId' }, { status: 400 });
+  }
+
+  // Firestore's REST API enforces the same security rules as the client SDK when
+  // given a user's ID token, so a successful read here proves isMemberOrAdmin().
+  const firestoreDocUrl = `https://firestore.googleapis.com/v1/projects/${PROJECT_ID}/databases/(default)/documents/feedback/${feedbackId}`;
+
+  const docRes = await fetch(firestoreDocUrl, {
+    headers: { Authorization: `Bearer ${idToken}` },
+  });
+
+  if (!docRes.ok) {
+    return NextResponse.json({ error: 'Not authorized to access this feedback item' }, { status: 403 });
+  }
+
+  const bug = parseFirestoreFields((await docRes.json()) as FirestoreDocument);
+
+  if (bug.type !== 'bug' && bug.type !== 'feature') {
+    return NextResponse.json(
+      { error: 'Only bug reports and feature requests can become GitHub issues' },
+      { status: 400 },
+    );
+  }
+  if (bug.isResolved) {
+    return NextResponse.json({ error: 'This feedback item is already resolved' }, { status: 400 });
+  }
+
+  const gitHubAccessToken = process.env.GITHUB_ACCESS_TOKEN;
+  const gitHubRepoOwner = process.env.GITHUB_REPO_OWNER;
+  const gitHubRepoName = process.env.GITHUB_REPO_NAME;
+
+  if (!gitHubAccessToken || !gitHubRepoOwner || !gitHubRepoName) {
+    return NextResponse.json({ error: 'GitHub integration is not configured on the server' }, { status: 500 });
+  }
+
+  const imgMarkdown =
+    typeof bug.attachedImage === 'string' && bug.attachedImage.startsWith('http')
+      ? `\n\n[Attached Image](${bug.attachedImage})`
+      : '';
+
+  let issueBody = `### Feedback Context\n\n- **Type:** ${bug.type}\n- **Contact Email:** ${bug.email ?? 'anonymous'}\n`;
+  if (bug.bugUrl && bug.bugUrl !== 'N/A') {
+    issueBody += `- **Context URL:** ${bug.bugUrl}\n`;
+  }
+  if (bug.type === 'bug') {
+    issueBody += `- **Category:** ${bug.bugType ?? 'N/A'}\n`;
+    issueBody += `\n### Detailed Description & Steps to Reproduce\n\n${bug.message}\n${imgMarkdown}`;
+  } else {
+    issueBody += `\n### Feature Request Details\n`;
+    if (bug.featureProblem) issueBody += `- **Problem:** ${bug.featureProblem}\n`;
+    if (bug.featureAlternatives) issueBody += `- **Alternatives Considered:** ${bug.featureAlternatives}\n`;
+    if (bug.featureSolution) issueBody += `- **Proposed Solution:** ${bug.featureSolution}\n`;
+    issueBody += `\n### Additional Description\n\n${bug.message}\n${imgMarkdown}`;
+  }
+
+  const title =
+    typeof bug.title === 'string' && bug.title.trim().length > 0
+      ? bug.title
+      : `${bug.type === 'bug' ? 'Bug' : 'Feature'}: ${typeof bug.bugType === 'string' ? bug.bugType : ''}`;
+
+  const issueRes = await fetch(`https://api.github.com/repos/${gitHubRepoOwner}/${gitHubRepoName}/issues`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${gitHubAccessToken}`,
+      Accept: 'application/vnd.github.v3+json',
+    },
+    body: JSON.stringify({
+      title,
+      body: issueBody.trim(),
+      labels: [bug.type === 'bug' ? 'bug' : 'enhancement'],
+    }),
+  });
+
+  if (!issueRes.ok) {
+    const errorData = (await issueRes.json().catch(() => ({}))) as { message?: string };
+    return NextResponse.json(
+      { error: errorData.message ?? `GitHub API responded with status ${issueRes.status}` },
+      { status: 502 },
+    );
+  }
+
+  const issue = (await issueRes.json()) as { html_url: string; number: number };
+
+  // Same isMemberOrAdmin() rule already covers update, so this reuses the verified idToken.
+  await fetch(`${firestoreDocUrl}?updateMask.fieldPaths=isResolved`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${idToken}`,
+    },
+    body: JSON.stringify({ fields: { isResolved: { booleanValue: true } } }),
+  });
+
+  return NextResponse.json({ issueUrl: issue.html_url, issueNumber: issue.number });
+}

--- a/src/app/api/feedback/create-issue/route.ts
+++ b/src/app/api/feedback/create-issue/route.ts
@@ -57,9 +57,9 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'This feedback item is already resolved' }, { status: 400 });
   }
 
-  const gitHubAccessToken = env.GITHUB_TOKEN;
-  const gitHubRepoOwner = env.GITHUB_OWNER;
-  const gitHubRepoName = env.GITHUB_REPO;
+  const gitHubAccessToken = env.GITHUB_ACCESS_TOKEN;
+  const gitHubRepoOwner = env.GITHUB_REPO_OWNER;
+  const gitHubRepoName = env.GITHUB_REPO_NAME;
 
   if (!gitHubAccessToken || !gitHubRepoOwner || !gitHubRepoName) {
     return NextResponse.json({ error: 'GitHub integration is not configured on the server' }, { status: 500 });

--- a/src/app/api/feedback/create-issue/route.ts
+++ b/src/app/api/feedback/create-issue/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
+import { env } from '@/env.js';
 
-const PROJECT_ID = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
+const PROJECT_ID = env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
 
 interface FirestoreValue {
   stringValue?: string;
@@ -29,14 +30,13 @@ export async function POST(req: NextRequest) {
 
   const body = (await req.json().catch(() => null)) as { feedbackId?: string } | null;
   const feedbackId = body?.feedbackId;
-  if (!feedbackId) {
-    return NextResponse.json({ error: 'Missing feedbackId' }, { status: 400 });
+  if (!feedbackId || typeof feedbackId !== 'string' || feedbackId.includes('/')) {
+    return NextResponse.json({ error: 'Invalid feedbackId' }, { status: 400 });
   }
 
   // Firestore's REST API enforces the same security rules as the client SDK when
   // given a user's ID token, so a successful read here proves isMemberOrAdmin().
-  const firestoreDocUrl = `https://firestore.googleapis.com/v1/projects/${PROJECT_ID}/databases/(default)/documents/feedback/${feedbackId}`;
-
+  const firestoreDocUrl = `https://firestore.googleapis.com/v1/projects/${PROJECT_ID}/databases/(default)/documents/feedback/${encodeURIComponent(feedbackId)}`;
   const docRes = await fetch(firestoreDocUrl, {
     headers: { Authorization: `Bearer ${idToken}` },
   });
@@ -57,9 +57,9 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'This feedback item is already resolved' }, { status: 400 });
   }
 
-  const gitHubAccessToken = process.env.GITHUB_ACCESS_TOKEN;
-  const gitHubRepoOwner = process.env.GITHUB_REPO_OWNER;
-  const gitHubRepoName = process.env.GITHUB_REPO_NAME;
+  const gitHubAccessToken = env.GITHUB_TOKEN;
+  const gitHubRepoOwner = env.GITHUB_OWNER;
+  const gitHubRepoName = env.GITHUB_REPO;
 
   if (!gitHubAccessToken || !gitHubRepoOwner || !gitHubRepoName) {
     return NextResponse.json({ error: 'GitHub integration is not configured on the server' }, { status: 500 });
@@ -115,7 +115,7 @@ export async function POST(req: NextRequest) {
   const issue = (await issueRes.json()) as { html_url: string; number: number };
 
   // Same isMemberOrAdmin() rule already covers update, so this reuses the verified idToken.
-  await fetch(`${firestoreDocUrl}?updateMask.fieldPaths=isResolved`, {
+  const patchRes = await fetch(`${firestoreDocUrl}?updateMask.fieldPaths=isResolved`, {
     method: 'PATCH',
     headers: {
       'Content-Type': 'application/json',
@@ -123,6 +123,14 @@ export async function POST(req: NextRequest) {
     },
     body: JSON.stringify({ fields: { isResolved: { booleanValue: true } } }),
   });
+
+  if (!patchRes.ok) {
+    return NextResponse.json({
+      issueUrl: issue.html_url,
+      issueNumber: issue.number,
+      warning: `GitHub issue created, but failed to mark feedback as resolved (status ${patchRes.status})`,
+    });
+  }
 
   return NextResponse.json({ issueUrl: issue.html_url, issueNumber: issue.number });
 }

--- a/src/env.js
+++ b/src/env.js
@@ -4,9 +4,9 @@ import { z } from "zod";
 export const env = createEnv({
   // Client-side Firebase variables
   server: {
-    GITHUB_TOKEN: z.string().optional(),
-    GITHUB_OWNER: z.string().optional(),
-    GITHUB_REPO: z.string().optional(),
+    GITHUB_ACCESS_TOKEN: z.string().optional(),
+    GITHUB_REPO_OWNER: z.string().optional(),
+    GITHUB_REPO_NAME: z.string().optional(),
   },
 
   client: {
@@ -21,9 +21,9 @@ export const env = createEnv({
 
   // Runtime environment variables
   runtimeEnv: {
-    GITHUB_TOKEN: process.env.GITHUB_TOKEN,
-    GITHUB_OWNER: process.env.GITHUB_OWNER,
-    GITHUB_REPO: process.env.GITHUB_REPO,
+    GITHUB_ACCESS_TOKEN: process.env.GITHUB_ACCESS_TOKEN,
+    GITHUB_REPO_OWNER: process.env.GITHUB_REPO_OWNER,
+    GITHUB_REPO_NAME: process.env.GITHUB_REPO_NAME,
     NEXT_PUBLIC_FIREBASE_API_KEY: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
     NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN:
       process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,


### PR DESCRIPTION
## Summary
- `firestore.rules` had no `allow create` rule for the `feedback` collection (dropped in an earlier "fix errors" commit), so every feedback submission failed with `Missing or insufficient permissions`. Restored `create` with validation matching what the form actually sends (`type`/`title`/`message`), and fixed `isMemberOrAdmin` calls that were missing `()`.
- The "Create GitHub Issue" admin action previously read `GITHUB_ACCESS_TOKEN` server-side but passed it as a prop into a `'use client'` component, which embeds it in the page payload sent to the browser. Moved issue creation into a new `src/app/api/feedback/create-issue` route: it forwards the caller's Firebase ID token to Firestore's REST API (enforcing the existing `isMemberOrAdmin()` rule) to authorize the request and fetch the feedback doc, then creates the GitHub issue using the token server-side only. The client now just calls this route with its ID token.

## Test plan
- [x] `firestore.rules` deployed to the `ap-students-32bbe` project and verified a live feedback submission from `/feedback` succeeds (previously failed with `Missing or insufficient permissions`)
- [x] `tsc --noEmit` and `eslint` clean on all changed files
- [x] Submit a Bug Report or Feature Request from `/feedback`, open it in `/admin/feedback`, click "Create GitHub Issue", confirm the issue is created and the token never appears in the page source