### PR TITLE
Make user subject browser page display FRQ tests

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -129,6 +129,11 @@ service cloud.firestore {
           allow read: if resource.data.isPublic == true || isMemberOrAdmin();
           allow write: if isMemberOrAdmin();
         }
+
+        match /frqs/{frq} {
+          allow read: if resource.data.isPublic == true || isMemberOrAdmin();
+          allow write: if isMemberOrAdmin();
+        }
       }
     }
     

--- a/src/app/subject/[slug]/(no-sidebar)/[unit]/frq/[id]/page.tsx
+++ b/src/app/subject/[slug]/(no-sidebar)/[unit]/frq/[id]/page.tsx
@@ -26,9 +26,16 @@ const Page = () => {
       setFrq(null);
 
       try {
-        // FRQs are top-level templates, just as an MCQ test is fetched as one
-        // document before its questions are rendered.
-        const docRef = doc(db, "frqTemplates", frqId);
+        // FRQs are stored under their subject/unit
+        const docRef = doc(
+          db,
+          "subjects",
+          subject,
+          "units",
+          unitId!,
+          "frqs",
+          frqId,
+        );
 
         const docSnap = await getDoc(docRef);
 

--- a/src/app/subject/[slug]/(sidebar)/page.tsx
+++ b/src/app/subject/[slug]/(sidebar)/page.tsx
@@ -8,9 +8,16 @@ import SubjectBreadcrumb from "@/components/subject/subject-breadcrumb";
 import TableOfContents from "@/components/subject/table-of-contents";
 import UnitAccordion from "@/components/subject/unit-accordion";
 import { useEffect, useState } from "react";
-import { doc, getDoc } from "firebase/firestore";
 import usePathname from "@/components/client/pathname";
 import { useUser } from "@/components/hooks/UserContext";
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  query,
+  where,
+} from "firebase/firestore";
 
 const Page = ({ params }: { params: { slug: string } }) => {
   const pathname = usePathname();
@@ -23,7 +30,11 @@ const Page = ({ params }: { params: { slug: string } }) => {
   useEffect(() => {
     const fetchSubject = async () => {
       try {
-        const isAuthorized = user && (user.access === "admin" || user.access === "member" || user.access === "grader");
+        const isAuthorized =
+          user &&
+          (user.access === "admin" ||
+            user.access === "member" ||
+            user.access === "grader");
         if (params.slug === "porting" && !isAuthorized) {
           setError("Subject not found. That's probably us, not you.");
           setLoading(false);
@@ -32,7 +43,44 @@ const Page = ({ params }: { params: { slug: string } }) => {
         const docRef = doc(db, "subjects", params.slug);
         const docSnap = await getDoc(docRef);
         if (docSnap.exists()) {
-          setSubject(docSnap.data() as Subject);
+          const subjectData = docSnap.data() as Subject;
+
+          const canPreview =
+            user?.access === "admin" || user?.access === "member";
+
+          const unitsWithFrqs = await Promise.all(
+            subjectData.units.map(async (unit) => {
+              const frqsCollectionRef = collection(
+                db,
+                "subjects",
+                params.slug,
+                "units",
+                unit.id,
+                "frqs",
+              );
+
+              const frqsQuery = canPreview
+                ? frqsCollectionRef
+                : query(frqsCollectionRef, where("isPublic", "==", true));
+
+              const frqsSnapshot = await getDocs(frqsQuery);
+
+              const frqs = frqsSnapshot.docs.map((frqDoc) => ({
+                ...frqDoc.data(),
+                id: frqDoc.id,
+              }));
+
+              return {
+                ...unit,
+                frqs,
+              };
+            }),
+          );
+
+          setSubject({
+            ...subjectData,
+            units: unitsWithFrqs,
+          });
         } else {
           setError("Subject not found. That's probably us, not you.");
         }

--- a/src/components/subject/unit-accordion.tsx
+++ b/src/components/subject/unit-accordion.tsx
@@ -6,7 +6,7 @@ import {
 } from "@/components/ui/accordion";
 import { formatSlug } from "@/lib/utils";
 import { type Unit } from "@/types/firestore";
-import { BookDashed, BookOpenCheck } from "lucide-react";
+import { BookDashed, BookOpenCheck, PencilLine, Pencil } from "lucide-react";
 import Link from "next/link";
 
 type Props = {
@@ -17,7 +17,13 @@ type Props = {
   hasUnit0?: boolean;
 };
 
-const UnitAccordion = ({ unit, pathname, unitIndex, preview, hasUnit0 }: Props) => {
+const UnitAccordion = ({
+  unit,
+  pathname,
+  unitIndex,
+  preview,
+  hasUnit0,
+}: Props) => {
   // uNum: display number used in URLs and badges.
   // 0-indexed when hasUnit0 is true (first array element = Unit 0).
   const uNum = hasUnit0 ? unitIndex : unitIndex + 1;
@@ -112,6 +118,48 @@ const UnitAccordion = ({ unit, pathname, unitIndex, preview, hasUnit0 }: Props) 
                 href={
                   preview
                     ? `${pathname.split("/").slice(0, 4).join("/")}/unit-${uNum}-${unit.id}/test/${test.id}`
+                    : "/apply"
+                }
+                className="ml-auto w-20 shrink-0 text-nowrap rounded-full border border-gray-400 px-2 py-0.5 text-center text-gray-600 transition-colors group-hover:border-primary group-hover:text-black sm:w-36 sm:py-0"
+              >
+                <span className="hidden group-hover:hidden sm:inline">
+                  Work In Progress
+                </span>
+                <span className="group-hover:hidden sm:hidden">WIP</span>
+                <span className="hidden group-hover:inline">
+                  {preview ? "Preview" : "Join FiveHive"}
+                </span>
+              </a>
+            </div>
+          ),
+        )}
+        {unit.frqs?.map((frq, frqIndex) =>
+          frq.isPublic ? (
+            <Link
+              className="flex items-center gap-x-2 font-semibold last:mb-0 hover:underline"
+              href={`${pathname.split("/").slice(0, 4).join("/")}/unit-${uNum}-${unit.id}/frq/${frq.id}`}
+              key={frq.id}
+            >
+              <PencilLine className="size-8" />
+              {frq.title
+                ? frq.title
+                : `Unit ${uNum} FRQ ${unit.frqs && unit.frqs.length > 1 ? ` ${frqIndex + 1}` : ""}`}
+            </Link>
+          ) : (
+            <div
+              className="group flex items-center gap-x-2 font-semibold last:mb-0"
+              key={frq.id}
+            >
+              <Pencil className="size-8 shrink-0 opacity-70" />
+              <span className="opacity-70 group-hover:underline">
+                {frq.title
+                  ? frq.title
+                  : `Unit ${uNum} FRQ ${unit.frqs && unit.frqs.length > 1 ? ` ${frqIndex + 1}` : ""}`}
+              </span>
+              <a
+                href={
+                  preview
+                    ? `${pathname.split("/").slice(0, 4).join("/")}/unit-${uNum}-${unit.id}/frq/${frq.id}`
                     : "/apply"
                 }
                 className="ml-auto w-20 shrink-0 text-nowrap rounded-full border border-gray-400 px-2 py-0.5 text-center text-gray-600 transition-colors group-hover:border-primary group-hover:text-black sm:w-36 sm:py-0"

--- a/src/types/firestore.ts
+++ b/src/types/firestore.ts
@@ -15,6 +15,7 @@ export type Unit = {
   // Use UnitTest.id as testId
   test?: boolean;
   testId?: string;
+  frqs?: UnitFRQ[];
 };
 
 export type UnitTest = {
@@ -23,6 +24,12 @@ export type UnitTest = {
   questions: QuestionFormat[];
   time: number;
   directions: string;
+  isPublic?: boolean;
+};
+
+export type UnitFRQ = {
+  id: string;
+  title?: string;
   isPublic?: boolean;
 };
 


### PR DESCRIPTION
# Description
I updated the user-facing browser page so right below the MCQ tests for a unit, the FRQ tests show up.  Each subject page now retrieves FRQs from the Firestore path `subjects/{subject}/units/{unitId}/frqs/{frqId}` based on the subject URL and unit IDs stored in the subject document. 


# Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


# Demo
<!-- Add a screenshot or a video demonstration when possible -->
<img width="1901" height="906" alt="image" src="https://github.com/user-attachments/assets/28bb39d9-4f78-48d4-8b52-45bbeb8d3815" />



# How Has This Been Tested? How can the reviewer test it?
<!-- Please describe how you tested your changes -->
<!-- Please describe with detail how a reviewer can test it -->

I tested this change locally using the Firebase Emulator Suite. I created a subjects collection with a calculus-ab document containing a unit whose ID was unit1. Under that subject, I created the path subjects/calculus-ab/units/unit1/frqs/frq-test-1 and added an FRQ document with title, isPublic, and questions fields. 
I then ran the server (npm run dev) and went to http://localhost:3000/subject/calculus-ab to test it out. Once I saw that it was working, I changed isPublic to false to check that the FRQ was hidden from signed-out users. 

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have performed a self-review of my own code
