### PR TITLE
Add rich-text formatting to image captions (fixes #337)

### DIFF
--- a/src/components/article-creator/Editor.tsx
+++ b/src/components/article-creator/Editor.tsx
@@ -86,10 +86,6 @@ type CustomImageTool = {
 
 const pendingStorageDeletes = new Set<string>();
 
-// Map of <CustomImage instance> -> accessor for the live rich caption snapshot.
-// Used so save() can read the latest value synchronously.
-const captionHostMap = new WeakMap<object, { get: () => RichCaption }>();
-
 function isStorageObjectNotFoundError(error: unknown): boolean {
   return (
     typeof error === "object" &&
@@ -222,10 +218,6 @@ class CustomImage extends Image {
       initial: initialKnown,
       placeholder: "Enter a caption (select text to format)...",
       onChange,
-    });
-
-    captionHostMap.set(this as unknown as HTMLElement, {
-      get: () => this._richCaption,
     });
   }
 

--- a/src/components/article-creator/Editor.tsx
+++ b/src/components/article-creator/Editor.tsx
@@ -32,13 +32,25 @@ import {
 } from "firebase/storage";
 import { buttonVariants } from "../ui/button";
 import { cn, resolveUploadContentType } from "@/lib/utils";
+import {
+  mountRichCaptionEditor,
+  resolveInitialRichCaption,
+  RICH_CAPTION_HOST_ATTR,
+} from "./caption-rich-text/mount";
+import type { RichCaption } from "./caption-rich-text/types";
+import {
+  serializeRichCaption,
+  richCaptionToPlainText,
+} from "./caption-rich-text/convert";
 
 interface EditorImageData {
   file: { url?: string; storageRefFullPath?: string; [key: string]: unknown };
   caption?: string;
+  richCaption?: RichCaption;
   withBorder?: boolean;
   withBackground?: boolean;
   stretched?: boolean;
+  centerImage?: boolean;
 }
 
 type MenuConfigItemList = Array<{
@@ -59,11 +71,24 @@ type CustomImageTool = {
   };
   block: {
     id: string;
+    container: HTMLElement;
+  };
+  ui: {
+    nodes: {
+      caption?: HTMLElement;
+      wrapper?: HTMLElement;
+    };
   };
   renderSettings(): MenuConfigItemList;
+  rendered?(): void;
+  save?(block: { holder: HTMLElement }): unknown;
 };
 
 const pendingStorageDeletes = new Set<string>();
+
+// Map of <CustomImage instance> -> accessor for the live rich caption snapshot.
+// Used so save() can read the latest value synchronously.
+const captionHostMap = new WeakMap<object, { get: () => RichCaption }>();
 
 function isStorageObjectNotFoundError(error: unknown): boolean {
   return (
@@ -77,6 +102,32 @@ function isStorageObjectNotFoundError(error: unknown): boolean {
 // https://github.com/editor-js/image/issues/54#issuecomment-1546833098
 // https://github.com/editor-js/image/issues/27
 class CustomImage extends Image {
+  /**
+   * Latest snapshot of the rich caption, kept up to date by the mounted
+   * CaptionRichTextEditor. `this._data.caption` mirrors the plain-text
+   * representation for backwards compatibility with downstream renderers.
+   */
+  private _richCaption: RichCaption = [];
+
+  // The EditorJS image tool's constructor signature is loosely typed at the
+  // boundary; the call below is safe because Image's runtime expects this
+  // shape.
+  constructor(args: Parameters<typeof Image>[0]) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    super(args);
+    // Capture any richCaption in the initial payload before the base class'
+    // `set data()` overwrites `_data.caption` with plain text.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+    const maybeData = (args as unknown as { data?: EditorImageData }).data;
+    if (maybeData) {
+      if (maybeData.richCaption) {
+        this._richCaption = resolveInitialRichCaption(maybeData.richCaption);
+      } else if (typeof maybeData.caption === "string" && maybeData.caption) {
+        this._richCaption = resolveInitialRichCaption(maybeData.caption);
+      }
+    }
+  }
+
   renderSettings(): MenuConfigItemList {
     const typedTool = this as unknown as CustomImageTool;
     const baseImageTool = Image as unknown as {
@@ -116,6 +167,91 @@ class CustomImage extends Image {
       },
       ...settingsArray,
     ] as unknown as MenuConfigItemList;
+  }
+
+  /**
+   * Called after the EditorJS image tool renders its UI. We locate the native
+   * caption element, replace it with a host node, and mount the React
+   * CaptionRichTextEditor into it. Repeated renders are idempotent.
+   */
+  rendered(): void {
+    const initialKnown =
+      this._richCaption.length > 0
+        ? this._richCaption
+        : resolveInitialRichCaption(
+            (this as unknown as { _data: EditorImageData })._data.richCaption ??
+              (this as unknown as { _data: EditorImageData })._data.caption ??
+              "",
+          );
+
+    const typed = this as unknown as {
+      ui: {
+        nodes: {
+          caption?: HTMLElement;
+          wrapper?: HTMLElement;
+        };
+      };
+      block: { container: HTMLElement; id: string };
+    };
+
+    // EditorJS's Image tool keeps its DOM refs on `this.ui.nodes`, not
+    // `this.nodes` directly — see @editorjs/image's Ui class.
+    const holder = typed.ui?.nodes?.caption ?? null;
+    if (!holder) return;
+
+    let host = holder.querySelector<HTMLElement>(`[${RICH_CAPTION_HOST_ATTR}]`);
+    if (!host) {
+      host = document.createElement("div");
+      host.setAttribute(RICH_CAPTION_HOST_ATTR, "true");
+      const cdx = holder;
+      cdx.contentEditable = "false";
+      cdx.innerHTML = "";
+      cdx.appendChild(host);
+    }
+
+    const onChange = (next: RichCaption): void => {
+      this._richCaption = next;
+      (this as unknown as { _data: EditorImageData })._data.richCaption =
+        serializeRichCaption(next);
+      (this as unknown as { _data: EditorImageData })._data.caption =
+        richCaptionToPlainText(next);
+    };
+
+    mountRichCaptionEditor({
+      host,
+      initial: initialKnown,
+      placeholder: "Enter a caption (select text to format)...",
+      onChange,
+    });
+
+    captionHostMap.set(this as unknown as HTMLElement, {
+      get: () => this._richCaption,
+    });
+  }
+
+  save(): {
+    file: EditorImageData["file"];
+    caption?: string;
+    richCaption?: RichCaption;
+    withBorder?: boolean;
+    withBackground?: boolean;
+    stretched?: boolean;
+    centerImage?: boolean;
+  } {
+    // Avoid calling the parent save(); it would try to read the caption
+    // element that we've repurposed, and we already have a structured value
+    // stored on `_data`. Read from `this._data` for non-caption fields.
+    const d = (this as unknown as { _data: EditorImageData })._data;
+    const rich = this._richCaption;
+    return {
+      file: d.file,
+      caption: richCaptionToPlainText(rich),
+      richCaption: serializeRichCaption(rich),
+      withBorder: d.withBorder,
+      withBackground: d.withBackground,
+      stretched: d.stretched,
+      centerImage: d.centerImage,
+    };
   }
 
   removed() {

--- a/src/components/article-creator/Renderer.tsx
+++ b/src/components/article-creator/Renderer.tsx
@@ -12,6 +12,12 @@ import type { QuestionFormat } from "@/types/questions";
 import "@/styles/katexStyling.css";
 import styles from "./Renderer.module.css";
 import { sanitizeAlignment } from "./alignment";
+import {
+  renderRichCaptionToHtml,
+} from "./caption-rich-text/render";
+import {
+  coerceRichCaption,
+} from "./caption-rich-text/convert";
 
 // Tool names the "alignment" BlockTune is registered on (see Editor.tsx).
 const ALIGNABLE_TYPES = new Set(["paragraph", "header", "list"]);
@@ -245,13 +251,22 @@ const customParsers: Record<
       );
     }
 
+    // Prefer richCaption for the figcaption body; fall back to plain caption.
+    const rich = (data as { richCaption?: unknown }).richCaption;
+    let captionBody = "";
+    if (Array.isArray(rich) && rich.length > 0) {
+      captionBody = renderRichCaptionToHtml(coerceRichCaption(rich));
+    } else if (typeof data.caption === "string" && data.caption.length > 0) {
+      captionBody = decodeEntities(data.caption);
+    }
+
     if (_config.image.use === "img") {
-      return `<img class="${imageConditions} ${imgClass}" src="${imageSrc}" alt="${data.caption}">`;
+      return `<img class="${imageConditions} ${imgClass}" src="${imageSrc}" alt="${data.caption ?? ""}">`;
     } else if (_config.image.use === "figure") {
       const figureClass = _config.image.figureClass ?? "";
       const figCapClass = _config.image.figCapClass ?? "";
 
-      return `<figure class="${figureClass}"><img class="${imgClass} ${imageConditions}" src="${imageSrc}" alt="${data.caption}"><figcaption class="${figCapClass}">${data.caption}</figcaption></figure>`;
+      return `<figure class="${figureClass}"><img class="${imgClass} ${imageConditions}" src="${imageSrc}" alt="${data.caption ?? ""}"><figcaption class="${figCapClass}">${captionBody}</figcaption></figure>`;
     }
     return "ERROR DISPLAYING IMAGE";
   },

--- a/src/components/article-creator/caption-rich-text/CaptionRichTextEditor.tsx
+++ b/src/components/article-creator/caption-rich-text/CaptionRichTextEditor.tsx
@@ -40,6 +40,20 @@ const EMPTY_SELECTION: SelectionState = {
   linkMark: null,
 };
 
+// Replace an element with its children, preserving their position in the tree.
+function unwrapElement(el: Element): void {
+  const parent = el.parentNode;
+  if (!parent) return;
+  while (el.firstChild) parent.insertBefore(el.firstChild, el);
+  parent.removeChild(el);
+}
+
+// Space (in px) reserved above the selection for the floating toolbar/popover
+// before falling back to rendering below the selection instead.
+const TOOLBAR_HEIGHT = 44;
+const LINK_POPOVER_HEIGHT = 60;
+const VIEWPORT_MARGIN = 8;
+
 export function CaptionRichTextEditor({
   value,
   onChange,
@@ -169,20 +183,30 @@ export function CaptionRichTextEditor({
         sel?.addRange(selection.range);
       }
       if (command === "highlight") {
-        // execCommand("HiliteColor"/"backColor") is unreliable, so wrap the
-        // selection in <mark> manually when there's any selected text.
+        // execCommand("HiliteColor"/"backColor") is unreliable, so <mark> is
+        // applied/removed manually when there's any selected text. Toggling
+        // off unwraps any <mark> the selection touches instead of nesting a
+        // new one, so "highlight again to remove it" actually works.
         const sel = window.getSelection();
-        if (sel && sel.rangeCount > 0 && !sel.isCollapsed) {
+        const root = editorRef.current;
+        if (sel && sel.rangeCount > 0 && !sel.isCollapsed && root) {
           const range = sel.getRangeAt(0);
-          const fragment = range.extractContents();
-          const mark = document.createElement("mark");
-          mark.appendChild(fragment);
-          range.insertNode(mark);
-          // Re-select what we just inserted
-          sel.removeAllRanges();
-          const newRange = document.createRange();
-          newRange.selectNodeContents(mark);
-          sel.addRange(newRange);
+          if (selection.activeMarks.has("highlight")) {
+            root.querySelectorAll("mark").forEach((mark) => {
+              if (range.intersectsNode(mark)) unwrapElement(mark);
+            });
+            sel.removeAllRanges();
+          } else {
+            const fragment = range.extractContents();
+            const mark = document.createElement("mark");
+            mark.appendChild(fragment);
+            range.insertNode(mark);
+            // Re-select what we just inserted
+            sel.removeAllRanges();
+            const newRange = document.createRange();
+            newRange.selectNodeContents(mark);
+            sel.addRange(newRange);
+          }
         }
       } else {
         document.execCommand(command);
@@ -190,7 +214,7 @@ export function CaptionRichTextEditor({
       commit();
       refreshSelectionState();
     },
-    [selection.range, commit, refreshSelectionState],
+    [selection.range, selection.activeMarks, commit, refreshSelectionState],
   );
 
   const toggleLink = useCallback(() => {
@@ -286,9 +310,17 @@ export function CaptionRichTextEditor({
   // position against a `position: absolute` ancestor that generally isn't
   // anchored to the document origin, pushing the toolbar off-screen for any
   // caption that isn't at the very top of the page.
+  //
+  // Prefer rendering above the selection, but flip below it when there isn't
+  // enough room above (e.g. the caption sits near the top of the viewport) so
+  // the toolbar/popover doesn't clamp to the viewport edge and cover the text
+  // the author just selected.
   const toolbarStyle: React.CSSProperties = selection.rect
     ? {
-        top: Math.max(8, selection.rect.top - 44),
+        top:
+          selection.rect.top - TOOLBAR_HEIGHT >= VIEWPORT_MARGIN
+            ? selection.rect.top - TOOLBAR_HEIGHT
+            : selection.rect.bottom + VIEWPORT_MARGIN,
         left: Math.min(
           window.innerWidth - 280,
           Math.max(8, selection.rect.left + selection.rect.width / 2 - 140),
@@ -298,7 +330,10 @@ export function CaptionRichTextEditor({
 
   const linkStyle: React.CSSProperties = selection.rect
     ? {
-        top: Math.max(8, selection.rect.top - 60),
+        top:
+          selection.rect.top - LINK_POPOVER_HEIGHT >= VIEWPORT_MARGIN
+            ? selection.rect.top - LINK_POPOVER_HEIGHT
+            : selection.rect.bottom + VIEWPORT_MARGIN,
         left: Math.min(
           window.innerWidth - 340,
           Math.max(8, selection.rect.left + selection.rect.width / 2 - 160),

--- a/src/components/article-creator/caption-rich-text/CaptionRichTextEditor.tsx
+++ b/src/components/article-creator/caption-rich-text/CaptionRichTextEditor.tsx
@@ -1,0 +1,473 @@
+"use client";
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Bold,
+  Italic,
+  Underline,
+  Highlighter,
+  Link as LinkIcon,
+  ExternalLink,
+  Trash2,
+} from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { isValidUrl } from "./sanitize";
+import { htmlToRichCaption, serializeRichCaption } from "./convert";
+import { renderRichCaptionToHtml } from "./render";
+import type { RichCaption, CaptionLinkMark } from "./types";
+
+export interface CaptionRichTextEditorProps {
+  value: RichCaption;
+  onChange: (next: RichCaption) => void;
+  placeholder?: string;
+  className?: string;
+}
+
+interface SelectionState {
+  range: Range | null;
+  rect: DOMRect | null;
+  activeMarks: Set<string>;
+  linkMark: CaptionLinkMark | null;
+}
+
+const EMPTY_SELECTION: SelectionState = {
+  range: null,
+  rect: null,
+  activeMarks: new Set(),
+  linkMark: null,
+};
+
+export function CaptionRichTextEditor({
+  value,
+  onChange,
+  placeholder = "Enter a caption...",
+  className,
+}: CaptionRichTextEditorProps) {
+  const editorRef = useRef<HTMLDivElement | null>(null);
+  const [selection, setSelection] = useState<SelectionState>(EMPTY_SELECTION);
+  const [linkPopoverOpen, setLinkPopoverOpen] = useState(false);
+  const [linkDraft, setLinkDraft] = useState("");
+  const [linkError, setLinkError] = useState<string | null>(null);
+  const lastExternalValue = useRef<RichCaption>(value);
+
+  // Re-render DOM content only when value changes from outside (initial load,
+  // undo, redo). While focused we treat the contentEditable as source of truth.
+  useEffect(() => {
+    const el = editorRef.current;
+    if (!el) return;
+    if (document.activeElement !== el && lastExternalValue.current !== value) {
+      el.innerHTML = renderRichCaptionToHtml(value);
+      lastExternalValue.current = value;
+    }
+  }, [value]);
+
+  // Mount initial content when the editor first becomes available.
+  useEffect(() => {
+    const el = editorRef.current;
+    if (el && el.innerHTML === "") {
+      el.innerHTML = renderRichCaptionToHtml(value);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const commit = useCallback(() => {
+    const el = editorRef.current;
+    if (!el) return;
+    const next = htmlToRichCaption(el.innerHTML);
+    const serialized = serializeRichCaption(next);
+    lastExternalValue.current = serialized;
+    onChange(serialized);
+  }, [onChange]);
+
+  const refreshSelectionState = useCallback(() => {
+    const sel = window.getSelection();
+    if (!sel || sel.rangeCount === 0 || sel.isCollapsed) {
+      setSelection(EMPTY_SELECTION);
+      setLinkPopoverOpen(false);
+      return;
+    }
+    const range = sel.getRangeAt(0);
+    const root = editorRef.current;
+    if (!root?.contains(range.commonAncestorContainer)) {
+      setSelection(EMPTY_SELECTION);
+      return;
+    }
+    let rect: DOMRect = range.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) {
+      const rects = range.getClientRects();
+      const firstRect = rects[0];
+      if (firstRect) rect = firstRect;
+    }
+
+    const activeMarks = new Set<string>();
+    let linkMark: CaptionLinkMark | null = null;
+
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    let node: Node | null = walker.currentNode;
+    while (node) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const textNode = node;
+      if (range.intersectsNode(textNode)) {
+        let el: Element | null = textNode.parentElement;
+        while (el && el !== root) {
+          const tag = el.tagName.toLowerCase();
+          if (tag === "strong" || tag === "b") activeMarks.add("bold");
+          else if (tag === "em" || tag === "i") activeMarks.add("italic");
+          else if (tag === "u") activeMarks.add("underline");
+          else if (tag === "mark") activeMarks.add("highlight");
+          else if (tag === "a") {
+            activeMarks.add("link");
+            const href = el.getAttribute("href") ?? "";
+            if (isValidUrl(href) && !linkMark) {
+              linkMark = { type: "link", href };
+            }
+          }
+          el = el.parentElement;
+        }
+      }
+      node = walker.nextNode();
+    }
+
+    setSelection({ range, rect, activeMarks, linkMark });
+  }, []);
+
+  useEffect(() => {
+    const handler = () => requestAnimationFrame(refreshSelectionState);
+    document.addEventListener("selectionchange", handler);
+    return () => document.removeEventListener("selectionchange", handler);
+  }, [refreshSelectionState]);
+
+  const handleBlur = useCallback(
+    (e: React.FocusEvent<HTMLDivElement>) => {
+      // Defer commit so click events on toolbar/popover can still fire first.
+      requestAnimationFrame(() => {
+        if (!editorRef.current) return;
+        if (
+          document.activeElement &&
+          editorRef.current.parentElement?.contains(document.activeElement)
+        ) {
+          return;
+        }
+        commit();
+        setSelection(EMPTY_SELECTION);
+        setLinkPopoverOpen(false);
+      });
+      void e;
+    },
+    [commit],
+  );
+
+  const applyCommand = useCallback(
+    (command: "bold" | "italic" | "underline" | "highlight") => {
+      editorRef.current?.focus();
+      if (selection.range) {
+        const sel = window.getSelection();
+        sel?.removeAllRanges();
+        sel?.addRange(selection.range);
+      }
+      if (command === "highlight") {
+        // execCommand("HiliteColor"/"backColor") is unreliable, so wrap the
+        // selection in <mark> manually when there's any selected text.
+        const sel = window.getSelection();
+        if (sel && sel.rangeCount > 0 && !sel.isCollapsed) {
+          const range = sel.getRangeAt(0);
+          const fragment = range.extractContents();
+          const mark = document.createElement("mark");
+          mark.appendChild(fragment);
+          range.insertNode(mark);
+          // Re-select what we just inserted
+          sel.removeAllRanges();
+          const newRange = document.createRange();
+          newRange.selectNodeContents(mark);
+          sel.addRange(newRange);
+        }
+      } else {
+        document.execCommand(command);
+      }
+      commit();
+      refreshSelectionState();
+    },
+    [selection.range, commit, refreshSelectionState],
+  );
+
+  const toggleLink = useCallback(() => {
+    setLinkError(null);
+    setLinkDraft(selection.linkMark?.href ?? "");
+    setLinkPopoverOpen(true);
+  }, [selection.linkMark]);
+
+  const confirmLink = useCallback(() => {
+    setLinkError(null);
+    const url = linkDraft.trim();
+    if (!url) {
+      setLinkError("URL cannot be empty.");
+      return;
+    }
+    if (!isValidUrl(url)) {
+      setLinkError("Enter a valid http(s):// or mailto: URL.");
+      return;
+    }
+    if (!selection.range || selection.range.collapsed) {
+      setLinkError("Select some text to link first.");
+      return;
+    }
+
+    editorRef.current?.focus();
+    const sel = window.getSelection();
+    sel?.removeAllRanges();
+    sel?.addRange(selection.range);
+
+    document.execCommand("createLink", false, url);
+    const root = editorRef.current;
+    if (root) {
+      const anchors = root.querySelectorAll("a[href]");
+      anchors.forEach((a) => {
+        const href = a.getAttribute("href") ?? "";
+        if (isValidUrl(href)) {
+          a.setAttribute("target", "_blank");
+          a.setAttribute("rel", "noopener noreferrer");
+        }
+      });
+    }
+    setLinkPopoverOpen(false);
+    setLinkDraft("");
+    commit();
+    refreshSelectionState();
+  }, [linkDraft, selection.range, commit, refreshSelectionState]);
+
+  const removeLink = useCallback(() => {
+    editorRef.current?.focus();
+    if (selection.range) {
+      const sel = window.getSelection();
+      sel?.removeAllRanges();
+      sel?.addRange(selection.range);
+    }
+    const sel = window.getSelection();
+    if (sel && sel.rangeCount > 0) {
+      let anchor: HTMLAnchorElement | null = null;
+      const node = sel.anchorNode;
+      if (node?.parentElement) {
+        anchor = node.parentElement.closest("a");
+      }
+      if (anchor && editorRef.current?.contains(anchor)) {
+        const r = document.createRange();
+        r.selectNodeContents(anchor);
+        sel.removeAllRanges();
+        sel.addRange(r);
+      }
+    }
+    document.execCommand("unlink");
+    setLinkPopoverOpen(false);
+    commit();
+    refreshSelectionState();
+  }, [selection.range, commit, refreshSelectionState]);
+
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      const html = e.clipboardData.getData("text/html");
+      const text = e.clipboardData.getData("text/plain");
+      const source = html || text;
+      if (!source) return;
+      const fragments = htmlToRichCaption(source);
+      const safe = renderRichCaptionToHtml(fragments);
+      document.execCommand("insertHTML", false, safe);
+      commit();
+    },
+    [commit],
+  );
+
+  // These use position: fixed (see globals.css), so they're positioned
+  // directly from the selection's viewport-relative rect with no scrollY
+  // offset. Adding scrollY here would double-count the page's scroll
+  // position against a `position: absolute` ancestor that generally isn't
+  // anchored to the document origin, pushing the toolbar off-screen for any
+  // caption that isn't at the very top of the page.
+  const toolbarStyle: React.CSSProperties = selection.rect
+    ? {
+        top: Math.max(8, selection.rect.top - 44),
+        left: Math.min(
+          window.innerWidth - 280,
+          Math.max(8, selection.rect.left + selection.rect.width / 2 - 140),
+        ),
+      }
+    : { display: "none" };
+
+  const linkStyle: React.CSSProperties = selection.rect
+    ? {
+        top: Math.max(8, selection.rect.top - 60),
+        left: Math.min(
+          window.innerWidth - 340,
+          Math.max(8, selection.rect.left + selection.rect.width / 2 - 160),
+        ),
+      }
+    : {};
+
+  return (
+    <div className={cn("caption-editor-root relative", className)}>
+      <div
+        ref={editorRef}
+        className="caption-editor-field"
+        contentEditable
+        suppressContentEditableWarning
+        onBlur={handleBlur}
+        onInput={commit}
+        onKeyUp={refreshSelectionState}
+        onMouseUp={refreshSelectionState}
+        onPaste={handlePaste}
+        data-placeholder={placeholder}
+        aria-label="Image caption"
+        role="textbox"
+        aria-multiline="true"
+        tabIndex={0}
+      />
+
+      {selection.rect && !linkPopoverOpen && (
+        <div
+          className="caption-toolbar"
+          style={toolbarStyle}
+          role="toolbar"
+          aria-label="Caption formatting"
+        >
+          <ToolbarButton
+            label="Bold"
+            icon={<Bold aria-hidden="true" />}
+            active={selection.activeMarks.has("bold")}
+            onClick={() => applyCommand("bold")}
+          />
+          <ToolbarButton
+            label="Italic"
+            icon={<Italic aria-hidden="true" />}
+            active={selection.activeMarks.has("italic")}
+            onClick={() => applyCommand("italic")}
+          />
+          <ToolbarButton
+            label="Underline"
+            icon={<Underline aria-hidden="true" />}
+            active={selection.activeMarks.has("underline")}
+            onClick={() => applyCommand("underline")}
+          />
+          <ToolbarButton
+            label="Highlight"
+            icon={<Highlighter aria-hidden="true" />}
+            active={selection.activeMarks.has("highlight")}
+            onClick={() => applyCommand("highlight")}
+          />
+          <ToolbarButton
+            label="Add or edit link"
+            icon={<LinkIcon aria-hidden="true" />}
+            active={selection.activeMarks.has("link")}
+            onClick={toggleLink}
+          />
+        </div>
+      )}
+
+      {linkPopoverOpen && (
+        <div
+          className="caption-link-popover"
+          style={linkStyle}
+          role="dialog"
+          aria-label="Edit link"
+        >
+          <Label htmlFor="caption-link-url" className="sr-only">
+            Link URL
+          </Label>
+          <Input
+            id="caption-link-url"
+            value={linkDraft}
+            onChange={(e) => setLinkDraft(e.target.value)}
+            placeholder="https://example.com"
+            aria-invalid={!!linkError}
+            aria-describedby={linkError ? "caption-link-error" : undefined}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                confirmLink();
+              } else if (e.key === "Escape") {
+                e.preventDefault();
+                setLinkPopoverOpen(false);
+                editorRef.current?.focus();
+              }
+            }}
+            autoFocus
+          />
+          {linkError && (
+            <p
+              id="caption-link-error"
+              role="alert"
+              className="caption-link-error"
+            >
+              {linkError}
+            </p>
+          )}
+          <div className="caption-link-actions">
+            <Button size="sm" onClick={confirmLink}>
+              Apply
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                setLinkPopoverOpen(false);
+                editorRef.current?.focus();
+              }}
+            >
+              Cancel
+            </Button>
+            {selection.linkMark && (
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={removeLink}
+                aria-label="Remove link"
+              >
+                <Trash2 aria-hidden="true" className="h-4 w-4" />
+                Remove
+              </Button>
+            )}
+            {selection.linkMark && (
+              <a
+                href={selection.linkMark.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="caption-link-open"
+                aria-label="Open link in new tab"
+              >
+                <ExternalLink aria-hidden="true" className="h-4 w-4" />
+                Open
+              </a>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface ToolbarButtonProps {
+  label: string;
+  icon: React.ReactNode;
+  active: boolean;
+  onClick: () => void;
+}
+
+function ToolbarButton({ label, icon, active, onClick }: ToolbarButtonProps) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "caption-toolbar-btn",
+        active && "caption-toolbar-btn-active",
+      )}
+      onClick={onClick}
+      aria-pressed={active}
+      aria-label={label}
+      title={label}
+    >
+      {icon}
+    </button>
+  );
+}

--- a/src/components/article-creator/caption-rich-text/convert.ts
+++ b/src/components/article-creator/caption-rich-text/convert.ts
@@ -1,0 +1,146 @@
+import type { RichCaption, CaptionSegment, CaptionMark } from "./types";
+import { isValidUrl } from "./sanitize";
+
+/**
+ * Convert a plain string caption (legacy format) into a RichCaption with one
+ * segment carrying no marks. This keeps old plain-text captions loadable.
+ */
+export function plainTextToRichCaption(text: string): RichCaption {
+  if (!text) return [];
+  return [{ text, marks: [] }];
+}
+
+/**
+ * Extract the plain-text representation of a RichCaption (used for the image's
+ * `alt` attribute and for validation checks visible to authors).
+ */
+export function richCaptionToPlainText(richCaption: RichCaption | undefined): string {
+  if (!richCaption || richCaption.length === 0) return "";
+  return richCaption.map((segment) => segment.text).join("");
+}
+
+/**
+ * Parse an HTML fragment (produced by editing or pasting) into a RichCaption.
+ * Only the supported marks (<strong>/<b>, <em>/<i>, <u>, <mark>, <a>) are
+ * retained; everything else is flattened to its text content.
+ */
+export function htmlToRichCaption(html: string): RichCaption {
+  if (!html) return [];
+
+  // Parse in a detached document so we never touch the live DOM.
+  const doc = document.implementation.createHTMLDocument("");
+  const container = doc.createElement("div");
+  container.innerHTML = html;
+
+  const segments: CaptionSegment[] = [];
+
+  function walk(node: Node, inheritedMarks: CaptionMark[]) {
+    node.childNodes.forEach((child) => {
+      if (child.nodeType === Node.TEXT_NODE) {
+        const text = child.textContent ?? "";
+        if (text.length > 0) {
+          segments.push({ text, marks: inheritedMarks.slice() });
+        }
+        return;
+      }
+      if (child.nodeType !== Node.ELEMENT_NODE) return;
+
+      const el = child as Element;
+      const tag = el.tagName.toLowerCase();
+      let marks = inheritedMarks;
+
+      switch (tag) {
+        case "strong":
+        case "b":
+          marks = marks.concat({ type: "bold" });
+          break;
+        case "em":
+        case "i":
+          marks = marks.concat({ type: "italic" });
+          break;
+        case "u":
+          marks = marks.concat({ type: "underline" });
+          break;
+        case "mark":
+          marks = marks.concat({ type: "highlight" });
+          break;
+        case "a": {
+          const href = el.getAttribute("href") ?? "";
+          if (isValidUrl(href)) {
+            marks = marks.concat({ type: "link", href });
+          }
+          break;
+        }
+        default:
+          // Unknown tags: descend but inherit no new marks.
+          break;
+      }
+      walk(el, marks);
+    });
+  }
+
+  walk(container, []);
+  return segments;
+}
+
+/**
+ * Serialize a RichCaption to a JSON-safe representation for storage. Currently
+ * the RichCaption is already JSON-safe, but this indirection keeps the storage
+ * shape stable if internal types change later.
+ */
+export function serializeRichCaption(rich: RichCaption): RichCaption {
+  return rich.map((segment) => ({
+    text: segment.text,
+    marks: segment.marks.map((mark) => {
+      if (mark.type === "link") {
+        const href = isValidUrl(mark.href) ? mark.href : "";
+        return { type: "link", href };
+      }
+      return { type: mark.type };
+    }),
+  }));
+}
+
+/**
+ * Coerce an unknown persisted value into a safe RichCaption. Handles legacy
+ * plain strings, malformed arrays, and partial segment data defensively.
+ */
+export function coerceRichCaption(value: unknown): RichCaption {
+  if (typeof value === "string") return plainTextToRichCaption(value);
+  if (!Array.isArray(value)) return [];
+
+  const segments: CaptionSegment[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object") continue;
+    const record = item as Record<string, unknown>;
+    const text = typeof record.text === "string" ? record.text : "";
+    if (!text) continue;
+    const rawMarks = record.marks;
+    const marks: CaptionMark[] = [];
+    if (Array.isArray(rawMarks)) {
+      for (const raw of rawMarks) {
+        if (!raw || typeof raw !== "object") continue;
+        const markRecord = raw as Record<string, unknown>;
+        const type = markRecord.type;
+        switch (type) {
+          case "bold":
+          case "italic":
+          case "underline":
+          case "highlight":
+            marks.push({ type });
+            break;
+          case "link": {
+            const href =
+              typeof markRecord.href === "string" ? markRecord.href : "";
+            if (isValidUrl(href)) marks.push({ type: "link", href });
+            break;
+          }
+          default:
+            break;
+        }
+      }
+    }
+    segments.push({ text, marks });
+  }
+  return segments;
+}

--- a/src/components/article-creator/caption-rich-text/index.ts
+++ b/src/components/article-creator/caption-rich-text/index.ts
@@ -1,0 +1,6 @@
+export * from "./types";
+export * from "./sanitize";
+export * from "./render";
+export * from "./convert";
+export { CaptionRichTextEditor } from "./CaptionRichTextEditor";
+export type { CaptionRichTextEditorProps } from "./CaptionRichTextEditor";

--- a/src/components/article-creator/caption-rich-text/mount.tsx
+++ b/src/components/article-creator/caption-rich-text/mount.tsx
@@ -1,0 +1,65 @@
+import { createRoot, type Root } from "react-dom/client";
+import { CaptionRichTextEditor } from "./CaptionRichTextEditor";
+import { coerceRichCaption } from "./convert";
+import type { RichCaption } from "./types";
+
+/**
+ * Generated to mark placeholder caption containers that we mount React into.
+ * This CSS class lets CustomImage quickly locate the active node within a block.
+ */
+export const RICH_CAPTION_HOST_ATTR = "data-rich-caption-host";
+
+/**
+ * Mount the CaptionRichTextEditor React component into a DOM host and surface
+ * the live value through a callback. The host replaces EditorJS' native
+ * contenteditable caption element so the rich-text editor becomes the new
+ * source of truth. Returns an unmount function.
+ */
+export function mountRichCaptionEditor(args: {
+  host: HTMLElement;
+  initial: RichCaption;
+  placeholder?: string;
+  onChange: (next: RichCaption) => void;
+}): { unmount(): void } {
+  let root: Root | null = null;
+  // Reuse an existing React root if we're remounting into the same host.
+  if (!args.host.hasAttribute(RICH_CAPTION_HOST_ATTR) || !rootCache.has(args.host)) {
+    root = createRoot(args.host);
+    rootCache.set(args.host, root);
+    args.host.setAttribute(RICH_CAPTION_HOST_ATTR, "true");
+  } else {
+    root = rootCache.get(args.host) ?? null;
+  }
+
+  const safeCaption: RichCaption = coerceRichCaption(args.initial);
+
+  root?.render(
+    <CaptionRichTextEditor
+      value={safeCaption}
+      placeholder={args.placeholder}
+      onChange={(next) => args.onChange(next)}
+    />,
+  );
+
+  return {
+    unmount() {
+      const cached = rootCache.get(args.host);
+      if (cached) {
+        cached.unmount();
+        rootCache.delete(args.host);
+        args.host.removeAttribute(RICH_CAPTION_HOST_ATTR);
+      }
+    },
+  };
+}
+
+const rootCache = new WeakMap<HTMLElement, Root>();
+
+/**
+ * Convert a (possibly legacy) caption value into the initial React render.
+ * Accepts either a string (legacy plain text) or a RichCaption array.
+ */
+export function resolveInitialRichCaption(value: unknown): RichCaption {
+  if (!value) return [];
+  return coerceRichCaption(value);
+}

--- a/src/components/article-creator/caption-rich-text/render.ts
+++ b/src/components/article-creator/caption-rich-text/render.ts
@@ -1,0 +1,67 @@
+import { sanitizeCaptionHtml, isValidUrl, sanitizeUrl } from "./sanitize";
+import type { RichCaption, CaptionSegment, CaptionLinkMark } from "./types";
+
+const AMP = String.fromCharCode(38);
+const LT = String.fromCharCode(60);
+const GT = String.fromCharCode(62);
+const QUOT = String.fromCharCode(34);
+
+function htmlEncode(str: string): string {
+  return str
+    .replace(/&/g, AMP + "amp;")
+    .replace(/</g, AMP + "lt;")
+    .replace(/>/g, AMP + "gt;")
+    .replace(/"/g, AMP + "quot;");
+}
+
+function wrap(tag: string, inner: string): string {
+  return LT + tag + GT + inner + LT + "/" + tag + GT;
+}
+
+// Emits the same semantic tags (<strong>/<em>/<u>/<mark>/<a>) that
+// convert.ts's htmlToRichCaption parses back into marks, so a segment
+// survives a render -> re-parse round trip (e.g. on the next keystroke)
+// without losing formatting. Marks nest inside one another so a link can
+// combine with bold/italic/underline/highlight instead of one replacing
+// the others.
+function renderSegmentToHtml(segment: CaptionSegment): string {
+  let html = htmlEncode(segment.text);
+  const has = (type: string) => segment.marks.some((m) => m.type === type);
+
+  if (has("bold")) html = wrap("strong", html);
+  if (has("italic")) html = wrap("em", html);
+  if (has("underline")) html = wrap("u", html);
+  if (has("highlight")) html = wrap("mark", html);
+
+  const linkMark = segment.marks.find(
+    (m): m is CaptionLinkMark => m.type === "link",
+  );
+  if (linkMark && isValidUrl(linkMark.href)) {
+    const safeHref = sanitizeUrl(linkMark.href);
+    const open =
+      LT +
+      "a href=" +
+      QUOT +
+      safeHref +
+      QUOT +
+      " target=" +
+      QUOT +
+      "_blank" +
+      QUOT +
+      " rel=" +
+      QUOT +
+      "noopener noreferrer" +
+      QUOT +
+      GT;
+    html = open + html + LT + "/a" + GT;
+  }
+
+  return html;
+}
+
+export function renderRichCaptionToHtml(richCaption: RichCaption): string {
+  const html = richCaption
+    .map((segment) => renderSegmentToHtml(segment))
+    .join("");
+  return sanitizeCaptionHtml(html);
+}

--- a/src/components/article-creator/caption-rich-text/sanitize.ts
+++ b/src/components/article-creator/caption-rich-text/sanitize.ts
@@ -1,0 +1,83 @@
+// Only allow these HTML elements and attributes for rich-text captions
+const ALLOWED_TAGS = new Set(["strong", "em", "u", "mark", "a"]);
+const ALLOWED_ATTRS = new Set(["href", "rel", "target"]);
+
+// Regex patterns for URL validation
+const DANGEROUS_PROTOCOLS = /^(javascript|data|vbscript|file):/i;
+const SCHEME_PREFIX = /^(https?:|mailto:)/i;
+
+/**
+ * Validate a caption link URL. Beyond rejecting dangerous schemes, this uses
+ * the URL parser to reject malformed URLs (e.g. missing host) and to resolve
+ * the *actual* scheme rather than trusting the raw string prefix. Any
+ * embedded whitespace is rejected outright, which also defeats tricks like
+ * sneaking "javascript:" after a leading space or tab. Bare "//host/path"
+ * links are rejected too, since browsers resolve those to an arbitrary
+ * external host using the current page's scheme (open-redirect / phishing
+ * risk) even though they start with what looks like a single "/".
+ */
+export function isValidUrl(url: string): boolean {
+  const trimmed = url.trim();
+  if (!trimmed) return false;
+  if (/\s/.test(trimmed)) return false;
+  if (DANGEROUS_PROTOCOLS.test(trimmed)) return false;
+
+  if (trimmed.startsWith("/") && !trimmed.startsWith("//")) {
+    return true;
+  }
+
+  if (!SCHEME_PREFIX.test(trimmed)) return false;
+
+  try {
+    const parsed = new URL(trimmed);
+    return (
+      parsed.protocol === "http:" ||
+      parsed.protocol === "https:" ||
+      parsed.protocol === "mailto:"
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function sanitizeUrl(url: string): string {
+  const trimmed = url.trim();
+  if (!isValidUrl(trimmed)) return "";
+  return trimmed;
+}
+
+/**
+ * Strip every tag and attribute we don't allow from an HTML fragment. Runs
+ * without a DOM so it can be used during server rendering. This is a deliberate
+ * whitelist implementation (no DOMPurify dependency) so the same module is
+ * usable from both client and server code paths.
+ */
+export function sanitizeCaptionHtml(html: string): string {
+  if (!html) return "";
+
+  const tagPattern = /<\/?([a-zA-Z][a-zA-Z0-9]*)\b([^>]*)>/g;
+  return html.replace(tagPattern, (full, rawTag: string, attrs: string) => {
+    const tag = rawTag.toLowerCase();
+    const isClosing = full.startsWith("</");
+    if (!ALLOWED_TAGS.has(tag)) return "";
+    if (isClosing) return `</${tag}>`;
+
+    // Whitelist attributes: only href, rel, target on <a>.
+    const attrPattern =
+      /([a-zA-Z][a-zA-Z0-9_-]*)\s*(?:=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>]+)))?/g;
+    let cleanedAttrs = "";
+    let m: RegExpExecArray | null;
+    while ((m = attrPattern.exec(attrs)) !== null) {
+      const name = (m[1] ?? "").toLowerCase();
+      const value = m[2] ?? m[3] ?? m[4] ?? "";
+      if (!ALLOWED_ATTRS.has(name)) continue;
+      if (name === "href") {
+        if (!isValidUrl(value)) continue;
+        cleanedAttrs += ` href="${value.replace(/"/g, "")}"`;
+      } else {
+        cleanedAttrs += ` ${name}="${value.replace(/"/g, "")}"`;
+      }
+    }
+    return `<${tag}${cleanedAttrs}>`;
+  });
+}

--- a/src/components/article-creator/caption-rich-text/sanitize.ts
+++ b/src/components/article-creator/caption-rich-text/sanitize.ts
@@ -14,7 +14,11 @@ const SCHEME_PREFIX = /^(https?:|mailto:)/i;
  * sneaking "javascript:" after a leading space or tab. Bare "//host/path"
  * links are rejected too, since browsers resolve those to an arbitrary
  * external host using the current page's scheme (open-redirect / phishing
- * risk) even though they start with what looks like a single "/".
+ * risk) even though they start with what looks like a single "/". The same
+ * applies to a leading "/\" (or any second character of "/" or "\"): the
+ * WHATWG URL parser treats "\" exactly like "/" for http(s) URLs, so
+ * "/\evil.com" resolves to "https://evil.com" in every major browser even
+ * though it isn't a "//" prefix.
  */
 export function isValidUrl(url: string): boolean {
   const trimmed = url.trim();
@@ -22,7 +26,7 @@ export function isValidUrl(url: string): boolean {
   if (/\s/.test(trimmed)) return false;
   if (DANGEROUS_PROTOCOLS.test(trimmed)) return false;
 
-  if (trimmed.startsWith("/") && !trimmed.startsWith("//")) {
+  if (trimmed.startsWith("/") && trimmed[1] !== "/" && trimmed[1] !== "\\") {
     return true;
   }
 

--- a/src/components/article-creator/caption-rich-text/types.ts
+++ b/src/components/article-creator/caption-rich-text/types.ts
@@ -1,0 +1,19 @@
+/** A formatting mark that can be applied to a range of caption text. */
+export type CaptionMark = 
+  | { type: "bold" }
+  | { type: "italic" }
+  | { type: "underline" }
+  | { type: "highlight" }
+  | { type: "link"; href: string };
+
+/** A link formatting mark (a CaptionMark variant extractor type). */
+export type CaptionLinkMark = Extract<CaptionMark, { type: "link" }>;
+
+/** A segment of caption text with optional formatting marks. */
+export interface CaptionSegment {
+  text: string;
+  marks: CaptionMark[];
+}
+
+/** The structured rich-text representation of a caption. */
+export type RichCaption = CaptionSegment[];

--- a/src/components/article-creator/editorjs-render.ts
+++ b/src/components/article-creator/editorjs-render.ts
@@ -10,6 +10,12 @@ import type { QuestionFormat } from "@/types/questions";
 import "@/styles/katexStyling.css";
 import styles from "./Renderer.module.css";
 import { sanitizeAlignment } from "./alignment";
+import {
+  renderRichCaptionToHtml,
+} from "./caption-rich-text/render";
+import {
+  coerceRichCaption,
+} from "./caption-rich-text/convert";
 
 // Tool names the "alignment" BlockTune is registered on (see Editor.tsx).
 const ALIGNABLE_TYPES = new Set(["paragraph", "header", "list"]);
@@ -245,13 +251,22 @@ const customParsers: Record<
       );
     }
 
+    // Prefer richCaption for the figcaption body; fall back to plain caption.
+    const rich = (data as { richCaption?: unknown }).richCaption;
+    let captionBody = "";
+    if (Array.isArray(rich) && rich.length > 0) {
+      captionBody = renderRichCaptionToHtml(coerceRichCaption(rich));
+    } else if (typeof data.caption === "string" && data.caption.length > 0) {
+      captionBody = decodeEntities(data.caption);
+    }
+
     if (_config.image.use === "img") {
-      return `<img class="${imageConditions} ${imgClass}" src="${imageSrc}" alt="${data.caption}">`;
+      return `<img class="${imageConditions} ${imgClass}" src="${imageSrc}" alt="${data.caption ?? ""}">`;
     } else if (_config.image.use === "figure") {
       const figureClass = _config.image.figureClass ?? "";
       const figCapClass = _config.image.figCapClass ?? "";
 
-      return `<figure class="${figureClass}"><img class="${imgClass} ${imageConditions}" src="${imageSrc}" alt="${data.caption}"><figcaption class="${figCapClass}">${data.caption}</figcaption></figure>`;
+      return `<figure class="${figureClass}"><img class="${imgClass} ${imageConditions}" src="${imageSrc}" alt="${data.caption ?? ""}"><figcaption class="${figCapClass}">${captionBody}</figcaption></figure>`;
     }
     return "ERROR DISPLAYING IMAGE";
   },

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -96,3 +96,173 @@
 .img.img-svg {
   @apply h-auto w-full max-w-[480px];
 }
+
+/* image rich-text caption editor ─────────────────────────────────────────── */
+
+.caption-editor-root {
+  position: relative;
+}
+
+.caption-editor-field {
+  @apply rounded-sm border p-2 text-sm outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2;
+  min-height: 2.5rem;
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+.caption-editor-field:empty::before {
+  content: attr(data-placeholder);
+  color: hsl(var(--muted-foreground));
+  pointer-events: none;
+}
+
+/* Inline formatting within the editable caption. These target the semantic
+   tags (<strong>/<em>/<u>/<mark>) that render.ts emits and convert.ts parses,
+   so styling stays in sync with whatever marks are actually persisted. */
+.caption-editor-field strong,
+figcaption strong {
+  font-weight: 700;
+}
+.caption-editor-field em,
+figcaption em {
+  font-style: italic;
+}
+.caption-editor-field u,
+figcaption u {
+  text-decoration: underline;
+}
+.caption-editor-field mark,
+figcaption mark {
+  background-color: rgba(255, 213, 79, 0.55);
+  color: inherit;
+  border-radius: 2px;
+  padding: 0 2px;
+}
+.dark .caption-editor-field mark,
+.dark figcaption mark {
+  background-color: rgba(255, 213, 79, 0.35);
+  color: inherit;
+}
+
+.caption-editor-field a,
+figcaption a {
+  color: hsl(var(--primary));
+  text-decoration: underline;
+  cursor: pointer;
+}
+figcaption a {
+  /* Published links: external link behaviour with safe attributes */
+  text-decoration-line: underline;
+  text-underline-offset: 2px;
+}
+
+/* Floating toolbar. position: fixed so the toolbar's viewport-relative
+   coordinates (computed straight from the selection's getBoundingClientRect)
+   don't need reconciling against whatever ancestor establishes the
+   containing block for `absolute` — which, for a caption nested inside the
+   article body, is essentially never the document origin. */
+.caption-toolbar {
+  position: fixed;
+  z-index: 50;
+  display: inline-flex;
+  gap: 2px;
+  padding: 4px;
+  background: hsl(var(--popover));
+  color: hsl(var(--popover-foreground));
+  border: 1px solid hsl(var(--border));
+  border-radius: 6px;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.18);
+}
+
+.caption-toolbar-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  border: none;
+  transition: background-color 120ms ease;
+}
+.caption-toolbar-btn:hover {
+  background: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+}
+.caption-toolbar-btn:focus-visible {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 2px;
+}
+.caption-toolbar-btn-active {
+  background: hsl(var(--primary) / 0.18);
+  color: hsl(var(--primary));
+}
+.caption-toolbar-btn-active:hover {
+  background: hsl(var(--primary) / 0.26);
+  color: hsl(var(--primary));
+}
+
+/* Link popover: also viewport-fixed, see .caption-toolbar above. */
+.caption-link-popover {
+  position: fixed;
+  z-index: 50;
+  width: 320px;
+  padding: 12px;
+  background: hsl(var(--popover));
+  color: hsl(var(--popover-foreground));
+  border: 1px solid hsl(var(--border));
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.22);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: calc(100vw - 16px);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.caption-link-error {
+  font-size: 0.75rem;
+  color: hsl(var(--destructive));
+  margin: 0;
+}
+
+.caption-link-actions {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.caption-link-open {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.8rem;
+  color: hsl(var(--primary));
+  text-decoration: none;
+  margin-left: auto;
+}
+
+@media (max-width: 640px) {
+  .caption-toolbar {
+    max-width: calc(100vw - 16px);
+    flex-wrap: wrap;
+  }
+  .caption-link-popover {
+    width: calc(100vw - 24px);
+  }
+}
+


### PR DESCRIPTION
# Description

Closes #337. Upgrades the Image block's caption field from plain text to a limited rich-text field: authors can now select caption text and apply **bold**, *italic*, underline, highlight, and hyperlinks, and combine them (e.g. a bold linked source title).

Key points for review:
- Caption content is stored as structured segments (`{ text, marks[] }`) rather than raw HTML, in a new `richCaption` field alongside the existing plain-text `caption` (kept in sync for backwards compatibility — old plain-text captions still load fine).
- A shared `caption-rich-text/` module (`convert.ts`, `render.ts`, `sanitize.ts`) is used by both the editor and the two published-article renderers (`Renderer.tsx`, `editorjs-render.ts`), so editor/preview/published output can't drift apart.
- Marks render as semantic tags (`<strong>`, `<em>`, `<u>`, `<mark>`, `<a>`), matching what the parser reads back — this keeps a render → edit → re-render round trip lossless.
- Links are validated against an allowlist of schemes (`http(s)`, `mailto`, root-relative paths) using the `URL` parser rather than a prefix check, and `//host` protocol-relative links are rejected (those resolve to an arbitrary external host and would otherwise be a phishing/open-redirect vector). A second sanitization pass strips any tag/attribute outside a small allowlist before anything is rendered.
- The floating formatting toolbar and link popover use `position: fixed` and are positioned from the selection's viewport-relative rect, so they render correctly regardless of where the caption sits on the page.


# Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

# Demo

<img width="668" height="503" alt="image" src="https://github.com/user-attachments/assets/4e42c225-7d27-4dc8-9fbe-e51e31403dcd" />

# How Has This Been Tested? How can the reviewer test it?

- `npx tsc --noEmit`, `npx next lint`, and `npx next build` all pass with no new errors/warnings.
- Manually verified against the real `EditorJS` `Image` tool (not just the React component in isolation) by temporarily mounting the `Editor` component with a seeded image block containing mixed formatting, then, via the actual mounted toolbar:
  - Applied and independently removed bold/italic/underline/highlight on sub-selections, including selections spanning a mark boundary.
  - Confirmed combined marks render and persist correctly (bold+link together, underline+highlight together).
  - Opened the link popover on text inside an existing link — confirmed it pre-fills the current URL and offers Apply/Cancel/Remove/"Open in new tab".
  - Confirmed `CustomImage.save()` returns the live `richCaption` (checked via `editor.save()`), and that reloading with that saved data re-renders identically (semantic-tag round trip).
- To test manually: open an article in the admin editor, add/edit an Image block, select text in the caption — a toolbar should appear with Bold/Italic/Underline/Highlight/Link. Try combining formats, add a link ("Add or edit link"), save, then reload the article and confirm the caption still renders with the same formatting in both the editor and the published view.

# Checklist

- [x] I have performed a self-review of my own code