### PR TITLE
Fix FRQ Firestore collection paths

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,12 +2,12 @@ rules_version = '2';
 
 service cloud.firestore {
   match /databases/{database}/documents {
-    
+
     // Centralized function to check if the user is authenticated
     function isAuthenticated() {
       return request.auth != null;
     }
-    
+
     // Centralized function to check if the user is an admin
     function isAdmin() {
       return isAuthenticated() && get(/databases/$(database)/documents/users/$(request.auth.uid)).data.access == "admin";
@@ -57,7 +57,7 @@ service cloud.firestore {
       let userDocAfter = getAfter(/databases/$(database)/documents/users/$(request.auth.uid));
       let userDataAfter = userDocAfter.data;
 
-      return userData.access != "banned" && (isAdmin() || (!("lastFrqResponseAt" in userData) && 
+      return userData.access != "banned" && (isAdmin() || (!("lastFrqResponseAt" in userData) &&
         "lastFrqResponseAt" in userDataAfter
       ) || (
         userData.lastFrqResponseAt < (request.time - duration.value(6, 'h'))
@@ -73,44 +73,70 @@ service cloud.firestore {
     // Digital testing FRQs deliberately use separate stores. Templates are
     // published prompts, the queue contains only ungraded responses, and a
     // grading result is kept separately for the student's dashboard.
-    match /frqTemplates/{templateId} {
-      allow read: if true;
-      allow create, update, delete: if isAdmin();
-    }
 
-    match /gradableFrqSubmissions/{submissionId} {
-      allow get, list: if isGraderOrAdmin() ||
-        (isAuthenticated() && resource.data.studentId == request.auth.uid);
-      allow create: if isAuthenticated()
-        && request.resource.data.keys().hasOnly(['templateId', 'studentId', 'responses', 'submittedAt'])
-        && request.resource.data.templateId is string
-        && request.resource.data.studentId == request.auth.uid
-        && request.resource.data.responses is map
-        && exists(/databases/$(database)/documents/frqTemplates/$(request.resource.data.templateId));
-      allow delete: if isGraderOrAdmin();
-    }
 
-    match /gradedFrqSubmissions/{resultId} {
-      allow get, list: if isGraderOrAdmin() ||
-        (isAuthenticated() && resource.data.studentId == request.auth.uid);
-      allow create: if isGraderOrAdmin()
-        && resultId == request.resource.data.sourceSubmissionId
-        && request.resource.data.keys().hasOnly(['sourceSubmissionId', 'templateId', 'studentId', 'responses', 'submittedAt', 'score', 'feedback', 'graderId', 'gradedAt'])
-        && request.resource.data.sourceSubmissionId is string
-        && request.resource.data.templateId is string
-        && request.resource.data.studentId is string
-        && request.resource.data.responses is map
-        && request.resource.data.score is string
-        && request.resource.data.feedback is string
-        && request.resource.data.graderId == request.auth.uid;
-      allow update, delete: if isGraderOrAdmin();
-    }
-    
+    match /ungraded-frqs/{submissionId} {
+  allow get, list: if isGraderOrAdmin() ||
+    (isAuthenticated() && resource.data.studentId == request.auth.uid);
+
+  allow create: if isAuthenticated()
+    && request.resource.data.keys().hasOnly([
+      'templateId',
+      'subject',
+      'unitId',
+      'studentId',
+      'responses',
+      'submittedAt'
+    ])
+    && request.resource.data.templateId is string
+    && request.resource.data.subject is string
+    && request.resource.data.unitId is string
+    && request.resource.data.studentId == request.auth.uid
+    && request.resource.data.responses is map
+    && exists(
+      /databases/$(database)/documents/subjects/$(request.resource.data.subject)/units/$(request.resource.data.unitId)/frqs/$(request.resource.data.templateId)
+    );
+
+  allow delete: if isGraderOrAdmin();
+}
+
+    match /graded-frqs/{resultId} {
+  allow get, list: if isGraderOrAdmin() ||
+    (isAuthenticated() && resource.data.studentId == request.auth.uid);
+
+  allow create: if isGraderOrAdmin()
+    && resultId == request.resource.data.sourceSubmissionId
+    && request.resource.data.keys().hasOnly([
+      'sourceSubmissionId',
+      'templateId',
+      'subject',
+      'unitId',
+      'studentId',
+      'responses',
+      'submittedAt',
+      'score',
+      'feedback',
+      'graderId',
+      'gradedAt'
+    ])
+    && request.resource.data.sourceSubmissionId is string
+    && request.resource.data.templateId is string
+    && request.resource.data.subject is string
+    && request.resource.data.unitId is string
+    && request.resource.data.studentId is string
+    && request.resource.data.responses is map
+    && request.resource.data.score is string
+    && request.resource.data.feedback is string
+    && request.resource.data.graderId == request.auth.uid;
+
+  allow update, delete: if isGraderOrAdmin();
+}
+
     // Admins can read/write all user documents
     match /users/{document=**} {
       allow read, write: if isAdmin();
     }
-		
+
     // Subjects and pages can be accessed by members and admins
     match /subjects/{subject} {
     	allow read: if true;
@@ -136,7 +162,7 @@ service cloud.firestore {
         }
       }
     }
-    
+
     match /pages/{document=**} {
     	allow read: if true;
       allow write: if isMemberOrAdmin();

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -7,13 +7,13 @@ import type { User } from "@/types/user";
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useUserManagement } from "./useUserManagement";
+import { getUngradedFrqsCollectionRef } from "@/lib/firestore/frqRefs";
 import apClassesData from "@/components/apClasses.json";
 import { useUser } from "../../components/hooks/UserContext";
 import Link from "next/link";
 import { cn, formatSlug } from "@/lib/utils";
 import { Ban, ClipboardPen, PencilRuler, ShieldUser, X } from "lucide-react";
 import {
-  collection,
   doc,
   getDocs,
   updateDoc,
@@ -36,7 +36,7 @@ useEffect(() => {
 
   const fetchUngradedFrqCount = async () => {
     try {
-      const collectionRef = collection(db, "gradableFrqSubmissions");
+      const collectionRef = getUngradedFrqsCollectionRef();
       const snapshot = await getDocs(collectionRef);
 
       setUngradedFrqCount(snapshot.size);

--- a/src/app/admin/subject/[slug]/[unit]/frq/[id]/page.tsx
+++ b/src/app/admin/subject/[slug]/[unit]/frq/[id]/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import FRQEditorRenderer from "@/components/frq/editorRenderer";
-import { db } from "@/lib/firebase";
+import { getFrqTemplateDocRef } from "@/lib/firestore/frqRefs";
 import type { FRQTemplate } from "@/types/frq";
-import { doc, getDoc } from "firebase/firestore";
+import { getDoc } from "firebase/firestore";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 
@@ -15,7 +15,8 @@ const Page = () => {
   const unitId = pathParts[1] ?? "";
   const frqId = pathParts[3] ?? "";
 
-  const [frqTemplate, setFrqTemplate] = useState<FRQTemplate | null>(null);
+  const [frqTemplate, setFrqTemplate] =
+    useState<FRQTemplate | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [frqFound, setFrqFound] = useState(false);
 
@@ -28,11 +29,17 @@ const Page = () => {
 
     const loadFrq = async () => {
       try {
-        const docRef = doc(db, "frqTemplates", frqId);
+        const docRef = getFrqTemplateDocRef(
+          subject,
+          unitId,
+          frqId,
+        );
+
         const docSnap = await getDoc(docRef);
 
         if (!docSnap.exists()) {
           setFrqFound(false);
+          setFrqTemplate(null);
           return;
         }
 
@@ -41,19 +48,11 @@ const Page = () => {
           ...(docSnap.data() as Omit<FRQTemplate, "id">),
         };
 
-        const belongsToRoute =
-          loadedFrq.subject === subject &&
-          loadedFrq.unitId === unitId;
-
-        if (!belongsToRoute) {
-          setFrqFound(false);
-          return;
-        }
-
         setFrqTemplate(loadedFrq);
         setFrqFound(true);
       } catch {
         setFrqFound(false);
+        setFrqTemplate(null);
       } finally {
         setIsLoading(false);
       }

--- a/src/app/admin/subject/[slug]/page.tsx
+++ b/src/app/admin/subject/[slug]/page.tsx
@@ -11,11 +11,9 @@ import {
   doc,
   getDoc,
   getDocs,
-  query,
   serverTimestamp,
   setDoc,
   updateDoc,
-  where,
   writeBatch,
 } from "firebase/firestore";
 import { Button, buttonVariants } from "@/components/ui/button";
@@ -27,6 +25,10 @@ import short from "short-uuid";
 import type { Subject, Unit } from "@/types/firestore";
 import UnitComponent from "./_components/unit";
 import { DEFAULT_PORTING_SUBJECT } from "@/lib/apPortingDefaults";
+import {
+  getFrqTemplateDocRef,
+  getFrqTemplatesCollectionRef,
+} from "@/lib/firestore/frqRefs";
 
 const translator = short(short.constants.flickrBase58);
 
@@ -86,55 +88,66 @@ export default function Page({ params }: { params: { slug: string } }) {
   const [newUnitTitle, setNewUnitTitle] = useState<string>("");
 
   useEffect(() => {
-    (async () => {
+    const fetchSubject = async () => {
       try {
-        if (user && (user.access === "admin" || user.access === "member")) {
-          const docRef = doc(db, "subjects", params.slug);
-          const docSnap = await getDoc(docRef);
-          const frqQuery = query(
-            collection(db, "frqTemplates"),
-            where("subject", "==", params.slug),
-          );
-          
-          const frqSnapshot = await getDocs(frqQuery);
-          
-          const loadedFrqs: FRQTemplate[] = frqSnapshot.docs.map((frqDoc) => ({
-            id: frqDoc.id,
-            ...(frqDoc.data() as Omit<FRQTemplate, "id">),
-          }));
-          
-          setFrqTemplates(loadedFrqs);
-
-          if (docSnap.exists()) {
-            // We have an existing subject
-            const fetched = docSnap.data() as Subject;
-            setSubjectTitle(fetched.title);
-            setUnits(fetched.units || []);
-            setHasUnit0(fetched.hasUnit0 ?? false);
-          } else {
-            // Subject not found -> create new with default template
-            // Also try to fill in subject title from `apClasses` if found
-            const foundTitle =
-              apClasses.find(
-                (apClass) =>
-                  formatSlug(apClass.replace(/AP /g, "")) === params.slug,
-              ) ?? "";
-            const newSubject = structuredClone(emptyData);
-            newSubject.title = foundTitle;
-            setSubjectTitle(newSubject.title);
-            setUnits(newSubject.units);
-          }
-          setSubjectLoading(false);
+        if (!user || (user.access !== "admin" && user.access !== "member")) {
+          return;
         }
-      } catch (err) {
-        console.error(err);
+
+        const subjectRef = doc(db, "subjects", params.slug);
+        const subjectSnapshot = await getDoc(subjectRef);
+
+        if (subjectSnapshot.exists()) {
+          const fetchedSubject = subjectSnapshot.data() as Subject;
+          const fetchedUnits = fetchedSubject.units || [];
+
+          setSubjectTitle(fetchedSubject.title);
+          setUnits(fetchedUnits);
+          setHasUnit0(fetchedSubject.hasUnit0 ?? false);
+
+          const frqSnapshots = await Promise.all(
+            fetchedUnits.map(async (unit) => {
+              const snapshot = await getDocs(
+                getFrqTemplatesCollectionRef(params.slug, unit.id),
+              );
+
+              return snapshot.docs.map(
+                (frqDoc): FRQTemplate => ({
+                  id: frqDoc.id,
+                  ...(frqDoc.data() as Omit<FRQTemplate, "id">),
+                  subject: params.slug,
+                  unitId: unit.id,
+                }),
+              );
+            }),
+          );
+
+          setFrqTemplates(frqSnapshots.flat());
+        } else {
+          const foundTitle =
+            apClasses.find(
+              (apClass) =>
+                formatSlug(apClass.replace(/AP /g, "")) === params.slug,
+            ) ?? "";
+
+          const newSubject = structuredClone(emptyData);
+          newSubject.title = foundTitle;
+
+          setSubjectTitle(newSubject.title);
+          setUnits(newSubject.units);
+          setFrqTemplates([]);
+        }
+
+        setSubjectLoading(false);
+      } catch (error) {
+        console.error(error);
         setError("Failed to fetch subject data.");
       } finally {
         setLoading(false);
       }
-    })().catch((err) => {
-      console.error("Error fetching subject:", err);
-    });
+    };
+
+    void fetchSubject();
   }, [user, params.slug, setError, setLoading]);
 
   /****************************************************
@@ -190,32 +203,37 @@ export default function Page({ params }: { params: { slug: string } }) {
     setUnits((prev) => prev.map((u) => (u.id === unitId ? updatedUnit : u)));
     setUnsavedChanges(true);
   };
-  
+
   /****************************************************
-   *                   FRQ ACTIONS
-   ****************************************************/
-  
-  const handleAddFrq = async (unitId: string, title: string) => {
-    const trimmedTitle = title.trim();
-  
-    if (!trimmedTitle) {
-      return;
-    }
-  
-    const frqId = generateShortId();
-  
-    const newFrq: FRQTemplate = {
-      id: frqId,
-      subject: params.slug,
-      unitId,
-      title: trimmedTitle,
-      directions: "",
-      questions: [],
-      isPublic: false,
-    };
-  
-    try {
-      await setDoc(doc(db, "frqTemplates", frqId), {
+ *                   FRQ ACTIONS
+ ****************************************************/
+
+const handleAddFrq = async (
+  unitId: string,
+  title: string,
+): Promise<void> => {
+  const trimmedTitle = title.trim();
+
+  if (!trimmedTitle) {
+    return;
+  }
+
+  const frqId = generateShortId();
+
+  const newFrq: FRQTemplate = {
+    id: frqId,
+    subject: params.slug,
+    unitId,
+    title: trimmedTitle,
+    directions: "",
+    questions: [],
+    isPublic: false,
+  };
+
+  try {
+    await setDoc(
+      getFrqTemplateDocRef(params.slug, unitId, frqId),
+      {
         subject: newFrq.subject,
         unitId: newFrq.unitId,
         title: newFrq.title,
@@ -224,63 +242,93 @@ export default function Page({ params }: { params: { slug: string } }) {
         isPublic: newFrq.isPublic,
         createdAt: serverTimestamp(),
         updatedAt: serverTimestamp(),
-      });
-  
-      setFrqTemplates((currentFrqs) => [...currentFrqs, newFrq]);
-      setUnsavedChanges(true);
-    } catch {
-      alert("Unable to add the FRQ. Please try again.");
-    }
-  };
-  
-  const handleRenameFrq = async (frqId: string, title: string) => {
-    const trimmedTitle = title.trim();
-  
-    if (!trimmedTitle) {
-      return;
-    }
-  
-    try {
-      await updateDoc(doc(db, "frqTemplates", frqId), {
+      },
+    );
+
+    setFrqTemplates((currentFrqs) => [
+      ...currentFrqs,
+      newFrq,
+    ]);
+
+    setUnsavedChanges(true);
+  } catch {
+    alert("Unable to add the FRQ. Please try again.");
+  }
+};
+
+const handleRenameFrq = async (
+  frqId: string,
+  title: string,
+): Promise<void> => {
+  const trimmedTitle = title.trim();
+
+  if (!trimmedTitle) {
+    return;
+  }
+
+  const frq = frqTemplates.find((item) => item.id === frqId);
+
+  if (!frq) {
+    alert("Unable to find the FRQ.");
+    return;
+  }
+
+  try {
+    await updateDoc(
+      getFrqTemplateDocRef(params.slug, frq.unitId, frqId),
+      {
         title: trimmedTitle,
         updatedAt: serverTimestamp(),
-      });
-  
-      setFrqTemplates((currentFrqs) =>
-        currentFrqs.map((frq) =>
-          frq.id === frqId ? { ...frq, title: trimmedTitle } : frq,
-        ),
-      );
+      },
+    );
 
-      setUnsavedChanges(true);
+    setFrqTemplates((currentFrqs) =>
+      currentFrqs.map((item) =>
+        item.id === frqId
+          ? { ...item, title: trimmedTitle }
+          : item,
+      ),
+    );
 
-    } catch {
-      alert("Unable to rename the FRQ. Please try again.");
-    }
-  };
-  
-  const handleFrqVisibilityChange = async (
-    frqId: string,
-    isPublic: boolean,
-  ) => {
-    try {
-      await updateDoc(doc(db, "frqTemplates", frqId), {
+    setUnsavedChanges(true);
+  } catch {
+    alert("Unable to rename the FRQ. Please try again.");
+  }
+};
+
+const handleFrqVisibilityChange = async (
+  frqId: string,
+  isPublic: boolean,
+): Promise<void> => {
+  const frq = frqTemplates.find((item) => item.id === frqId);
+
+  if (!frq) {
+    alert("Unable to find the FRQ.");
+    return;
+  }
+
+  try {
+    await updateDoc(
+      getFrqTemplateDocRef(params.slug, frq.unitId, frqId),
+      {
         isPublic,
         updatedAt: serverTimestamp(),
-      });
-  
-      setFrqTemplates((currentFrqs) =>
-        currentFrqs.map((frq) =>
-          frq.id === frqId ? { ...frq, isPublic } : frq,
-        ),
-      );
+      },
+    );
 
-      setUnsavedChanges(true);
+    setFrqTemplates((currentFrqs) =>
+      currentFrqs.map((item) =>
+        item.id === frqId
+          ? { ...item, isPublic }
+          : item,
+      ),
+    );
 
-    } catch {
-      alert("Unable to update the FRQ visibility. Please try again.");
-    }
-  };
+    setUnsavedChanges(true);
+  } catch {
+    alert("Unable to update the FRQ visibility. Please try again.");
+  }
+};
   /****************************************************
    *                   SAVE ACTION
    * This function will force delete anything in the db that isnt in the local to keep db clean

--- a/src/app/frq-feedback/[id]/page.tsx
+++ b/src/app/frq-feedback/[id]/page.tsx
@@ -1,23 +1,30 @@
 "use client";
 
-import FRQFeedbackRenderer from "@/components/frq/feedbackRenderer";
-import { db } from "@/lib/firebase";
-import { doc, getDoc } from "firebase/firestore";
-import { useEffect, useState } from "react";
 import usePathname from "@/components/client/pathname";
+import FRQFeedbackRenderer from "@/components/frq/feedbackRenderer";
+import { getGradedFrqDocRef } from "@/lib/firestore/frqRefs";
+import { getDoc } from "firebase/firestore";
+import { useEffect, useState } from "react";
 
 type FeedbackStatus = "loading" | "found" | "not-found";
 
 const Page = () => {
   const pathname = usePathname() ?? "";
   const frqId = pathname.split("/").at(-1) ?? "";
+
   const [status, setStatus] = useState<FeedbackStatus>("loading");
 
   useEffect(() => {
     const fetchFeedback = async () => {
       setStatus("loading");
+
+      if (!frqId) {
+        setStatus("not-found");
+        return;
+      }
+
       try {
-        const docRef = doc(db, "gradedFrqSubmissions", frqId);
+        const docRef = getGradedFrqDocRef(frqId);
         const docSnap = await getDoc(docRef);
 
         setStatus(docSnap.exists() ? "found" : "not-found");
@@ -31,15 +38,15 @@ const Page = () => {
   }, [frqId]);
 
   if (status === "loading") {
-    return <p>Loading...</p>;
+    return <div>Loading...</div>;
   }
 
   if (status === "not-found") {
-    return <p>Feedback not found.</p>;
+    return <div>Feedback not found.</div>;
   }
 
   return (
-    <div className="px-8 py-12">
+    <div>
       {/*
         A real `feedbackData` cannot be built from a GradedFRQSubmission yet, so
         the renderer intentionally falls back to its mock data here.
@@ -53,10 +60,10 @@ const Page = () => {
         rubric criteria and no question/part tree.
 
         Building a document from what is stored today would render 0/0 points
-        with empty rubric rows and drop the grader's written feedback entirely --
-        strictly more misleading than the fallback. Closing this needs either the
-        grading write side to persist per-criterion scores and per-part feedback,
-        or FRQFeedbackDocument to accept an aggregate score/feedback pair.
+        with empty rubric rows and drop the grader's written feedback entirely.
+        Closing this needs either the grading write side to persist per-criterion
+        scores and per-part feedback, or FRQFeedbackDocument to accept an
+        aggregate score/feedback pair.
       */}
       <FRQFeedbackRenderer />
     </div>

--- a/src/app/frq-grading/[id]/page.tsx
+++ b/src/app/frq-grading/[id]/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import FRQGradingRenderer from "@/components/frq/gradingRenderer";
-import { db } from "@/lib/firebase";
+import { getUngradedFrqDocRef } from "@/lib/firestore/frqRefs";
 import type { GradableFRQSubmission } from "@/types/frq";
-import { doc, getDoc } from "firebase/firestore";
+import { getDoc } from "firebase/firestore";
 import { useEffect, useState } from "react";
 
 type PageProps = {
@@ -19,7 +19,7 @@ const Page = ({ params }: PageProps) => {
   useEffect(() => {
     const fetchFrq = async () => {
       try {
-        const docRef = doc(db, "gradableFrqSubmissions", params.id);
+        const docRef = getUngradedFrqDocRef(params.id);
         const docSnap = await getDoc(docRef);
 
         if (docSnap.exists()) {
@@ -45,7 +45,7 @@ const Page = ({ params }: PageProps) => {
     return <div>Loading...</div>;
   }
 
-  return <FRQGradingRenderer frq={frq ?? null} />;
+  return <FRQGradingRenderer frq={frq} />;
 };
 
 export default Page;

--- a/src/app/frq-grading/page.tsx
+++ b/src/app/frq-grading/page.tsx
@@ -1,51 +1,49 @@
 "use client";
 
-import FRQGradingRenderer from "@/components/frq/gradingRenderer";
-import { getUngradedFrqDocRef } from "@/lib/firestore/frqRefs";
-import type { GradableFRQSubmission } from "@/types/frq";
-import { getDoc } from "firebase/firestore";
+import Link from "next/link";
+import { getUngradedFrqsCollectionRef } from "@/lib/firestore/frqRefs";
+import { getDocs, orderBy, query } from "firebase/firestore";
 import { useEffect, useState } from "react";
 
-type PageProps = {
-  params: {
-    id: string;
-  };
-};
-
-const Page = ({ params }: PageProps) => {
-  const [frq, setFrq] = useState<GradableFRQSubmission | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+const Page = () => {
+  const [frqIds, setFrqIds] = useState<string[] | null>(null);
 
   useEffect(() => {
-    const fetchFrq = async () => {
-      try {
-        const docRef = getUngradedFrqDocRef(params.id);
-        const docSnap = await getDoc(docRef);
-
-        if (docSnap.exists()) {
-          setFrq({
-            id: docSnap.id,
-            ...(docSnap.data() as GradableFRQSubmission),
-          });
-        } else {
-          setFrq(null);
-        }
-      } catch (error) {
-        console.error("Error fetching FRQ:", error);
-        setFrq(null);
-      } finally {
-        setIsLoading(false);
-      }
+    const fetchFrqs = async () => {
+      const collectionRef = getUngradedFrqsCollectionRef();
+            const snapshot = await getDocs(
+        query(collectionRef, orderBy("submittedAt", "desc")),
+      );
+      setFrqIds(snapshot.docs.map((doc) => doc.id));
     };
 
-    void fetchFrq();
-  }, [params.id]);
+    fetchFrqs().catch((error) => {
+      console.error("Error fetching ungraded FRQs:", error);
+      setFrqIds([]);
+    });
+  }, []);
 
-  if (isLoading) {
+  if (frqIds === null) {
     return <div>Loading...</div>;
   }
 
-  return <FRQGradingRenderer frq={frq} />;
+  return (
+    <div>
+      <h1>Ungraded FRQs</h1>
+
+      {frqIds.length === 0 ? (
+        <p>No ungraded FRQs found.</p>
+      ) : (
+        <ul>
+          {frqIds.map((id) => (
+            <li key={id}>
+              <Link href={`/frq-grading/${id}`}>{id}</Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
 };
 
 export default Page;

--- a/src/app/frq-grading/page.tsx
+++ b/src/app/frq-grading/page.tsx
@@ -1,49 +1,51 @@
 "use client";
 
-import Link from "next/link";
-import { db } from "@/lib/firebase";
-import { collection, getDocs, orderBy, query } from "firebase/firestore";
+import FRQGradingRenderer from "@/components/frq/gradingRenderer";
+import { getUngradedFrqDocRef } from "@/lib/firestore/frqRefs";
+import type { GradableFRQSubmission } from "@/types/frq";
+import { getDoc } from "firebase/firestore";
 import { useEffect, useState } from "react";
 
-const Page = () => {
-  const [frqIds, setFrqIds] = useState<string[] | null>(null);
+type PageProps = {
+  params: {
+    id: string;
+  };
+};
+
+const Page = ({ params }: PageProps) => {
+  const [frq, setFrq] = useState<GradableFRQSubmission | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    const fetchFrqs = async () => {
-      const collectionRef = collection(db, "gradableFrqSubmissions");
-      const snapshot = await getDocs(
-        query(collectionRef, orderBy("submittedAt", "desc")),
-      );
-      setFrqIds(snapshot.docs.map((doc) => doc.id));
+    const fetchFrq = async () => {
+      try {
+        const docRef = getUngradedFrqDocRef(params.id);
+        const docSnap = await getDoc(docRef);
+
+        if (docSnap.exists()) {
+          setFrq({
+            id: docSnap.id,
+            ...(docSnap.data() as GradableFRQSubmission),
+          });
+        } else {
+          setFrq(null);
+        }
+      } catch (error) {
+        console.error("Error fetching FRQ:", error);
+        setFrq(null);
+      } finally {
+        setIsLoading(false);
+      }
     };
 
-    fetchFrqs().catch((error) => {
-      console.error("Error fetching ungraded FRQs:", error);
-      setFrqIds([]);
-    });
-  }, []);
+    void fetchFrq();
+  }, [params.id]);
 
-  if (frqIds === null) {
+  if (isLoading) {
     return <div>Loading...</div>;
   }
 
-  return (
-    <div>
-      <h1>Ungraded FRQs</h1>
-
-      {frqIds.length === 0 ? (
-        <p>No ungraded FRQs found.</p>
-      ) : (
-        <ul>
-          {frqIds.map((id) => (
-            <li key={id}>
-              <Link href={`/frq-grading/${id}`}>{id}</Link>
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
-  );
+  return <FRQGradingRenderer frq={frq} />;
 };
 
 export default Page;

--- a/src/app/subject/[slug]/(no-sidebar)/[unit]/frq/[id]/page.tsx
+++ b/src/app/subject/[slug]/(no-sidebar)/[unit]/frq/[id]/page.tsx
@@ -1,15 +1,19 @@
 "use client";
 
-import FRQTestRenderer from "@/components/frq/testRenderer";
 import usePathname from "@/components/client/pathname";
-import { db } from "@/lib/firebase";
-import { doc, getDoc } from "firebase/firestore";
+import FRQTestRenderer from "@/components/frq/testRenderer";
+import { getFrqTemplateDocRef } from "@/lib/firestore/frqRefs";
+import { getDoc } from "firebase/firestore";
 import { useEffect, useState } from "react";
 
 const Page = () => {
   const pathname = usePathname();
 
-  const basePath = pathname.split("/").filter(Boolean).slice(-4).join("_");
+  const basePath = pathname
+    .split("/")
+    .filter(Boolean)
+    .slice(-4)
+    .join("_");
 
   const subject = basePath.split("_")[0]!;
   const unitId = basePath.split("_")[1]?.split("-").at(-1);
@@ -26,14 +30,14 @@ const Page = () => {
       setFrq(null);
 
       try {
-        // FRQs are stored under their subject/unit
-        const docRef = doc(
-          db,
-          "subjects",
+        if (!subject || !unitId || !frqId) {
+          setError("Invalid FRQ route.");
+          return;
+        }
+
+        const docRef = getFrqTemplateDocRef(
           subject,
-          "units",
-          unitId!,
-          "frqs",
+          unitId,
           frqId,
         );
 
@@ -55,14 +59,22 @@ const Page = () => {
       }
     };
 
-    fetchFRQ().catch((error) => {
-      console.error("Error fetching FRQ data:", error);
-      setError("Error fetching FRQ data.");
-      setLoading(false);
-    });
+    void fetchFRQ();
   }, [subject, unitId, frqId]);
 
-  return <FRQTestRenderer frq={frq} loading={loading} error={error} />;
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>{error}</div>;
+  }
+
+  if (!frq) {
+    return <div>FRQ not found.</div>;
+  }
+
+  return <FRQTestRenderer frq={frq} />;
 };
 
 export default Page;

--- a/src/app/subject/[slug]/(no-sidebar)/[unit]/frq/[id]/page.tsx
+++ b/src/app/subject/[slug]/(no-sidebar)/[unit]/frq/[id]/page.tsx
@@ -47,6 +47,8 @@ const Page = () => {
           setFrq({
             id: docSnap.id,
             ...docSnap.data(),
+            subject,
+            unitId,
           });
         } else {
           setFrq(null);

--- a/src/components/frq/gradingRenderer.tsx
+++ b/src/components/frq/gradingRenderer.tsx
@@ -112,17 +112,19 @@ const FRQGradingRenderer = ({ frq }: FRQGradingRendererProps) => {
         const queuedSubmission =
           queueSnapshot.data() as GradableFRQSubmission;
 
-        transaction.set(resultRef, {
-          sourceSubmissionId: frq.id,
-          templateId: queuedSubmission.templateId,
-          studentId: queuedSubmission.studentId,
-          responses: queuedSubmission.responses,
-          submittedAt: queuedSubmission.submittedAt,
-          score: `${earnedPoints}/${possiblePoints}`,
-          feedback: feedback.trim(),
-          graderId: user.uid,
-          gradedAt: serverTimestamp(),
-        });
+          transaction.set(resultRef, {
+            sourceSubmissionId: frq.id,
+            templateId: queuedSubmission.templateId,
+            subject: queuedSubmission.subject,
+            unitId: queuedSubmission.unitId,
+            studentId: queuedSubmission.studentId,
+            responses: queuedSubmission.responses,
+            submittedAt: queuedSubmission.submittedAt,
+            score: `${earnedPoints}/${possiblePoints}`,
+            feedback: feedback.trim(),
+            graderId: user.uid,
+            gradedAt: serverTimestamp(),
+          });
 
         transaction.delete(queueRef);
       });

--- a/src/components/frq/gradingRenderer.tsx
+++ b/src/components/frq/gradingRenderer.tsx
@@ -10,13 +10,17 @@ import {
   ChevronUp,
   LogOut,
 } from "lucide-react";
-import { doc, runTransaction, serverTimestamp } from "firebase/firestore";
-
+import { runTransaction, serverTimestamp } from "firebase/firestore";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  getGradedFrqDocRef,
+  getUngradedFrqDocRef,
+} from "@/lib/firestore/frqRefs";
+
 import { useUser } from "@/components/hooks/UserContext";
 import type { GradableFRQSubmission } from "@/types/frq";
 
@@ -83,17 +87,17 @@ const FRQGradingRenderer = ({ frq }: FRQGradingRendererProps) => {
     (total, item) => total + item.possiblePoints,
     0,
   );
-
   const submitGradeReport = async () => {
     if (!frq.id || !user || !feedback.trim()) return;
 
     setIsSubmitting(true);
+
     try {
       // Use the submission ID as the result ID and atomically claim the queue
       // item. Firestore retries concurrent transactions, so only one grader
       // can successfully issue a report for a submission.
-      const queueRef = doc(db, "gradableFrqSubmissions", frq.id);
-      const resultRef = doc(db, "gradedFrqSubmissions", frq.id);
+      const queueRef = getUngradedFrqDocRef(frq.id);
+      const resultRef = getGradedFrqDocRef(frq.id);
 
       await runTransaction(db, async (transaction) => {
         const [queueSnapshot, resultSnapshot] = await Promise.all([
@@ -105,7 +109,9 @@ const FRQGradingRenderer = ({ frq }: FRQGradingRendererProps) => {
           throw new Error("This submission has already been graded.");
         }
 
-        const queuedSubmission = queueSnapshot.data() as GradableFRQSubmission;
+        const queuedSubmission =
+          queueSnapshot.data() as GradableFRQSubmission;
+
         transaction.set(resultRef, {
           sourceSubmissionId: frq.id,
           templateId: queuedSubmission.templateId,
@@ -117,12 +123,14 @@ const FRQGradingRenderer = ({ frq }: FRQGradingRendererProps) => {
           graderId: user.uid,
           gradedAt: serverTimestamp(),
         });
+
         transaction.delete(queueRef);
       });
 
       window.alert("Grade report submitted.");
     } catch (error) {
       console.error("Error submitting FRQ grade:", error);
+
       window.alert(
         error instanceof Error &&
           error.message === "This submission has already been graded."

--- a/src/components/frq/testRenderer.tsx
+++ b/src/components/frq/testRenderer.tsx
@@ -247,8 +247,10 @@ const FRQTestRenderer = ({
 
   const submitForGrading = async () => {
     const templateId = typeof frq?.id === "string" ? frq.id : null;
+    const subject = typeof frq?.subject === "string" ? frq.subject : null;
+    const unitId = typeof frq?.unitId === "string" ? frq.unitId : null;
 
-    if (!user || !templateId) {
+    if (!user || !templateId || !subject || !unitId) {
       window.alert("Please sign in before submitting this FRQ for grading.");
       return;
     }
@@ -258,6 +260,8 @@ const FRQTestRenderer = ({
     try {
       await addDoc(getUngradedFrqsCollectionRef(), {
         templateId,
+        subject,
+        unitId,
         studentId: user.uid,
         responses,
         submittedAt: serverTimestamp(),

--- a/src/components/frq/testRenderer.tsx
+++ b/src/components/frq/testRenderer.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import FRQResponseEditor from "@/components/frq/responseEditor";
+import { useUser } from "@/components/hooks/UserContext";
 import FRQFooter from "@/components/frq/FRQFooter";
+import FRQResponseEditor from "@/components/frq/responseEditor";
+import { getUngradedFrqsCollectionRef } from "@/lib/firestore/frqRefs";
+import { addDoc, serverTimestamp } from "firebase/firestore";
 import { Bookmark, LogOut } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
-import { addDoc, collection, serverTimestamp } from "firebase/firestore";
-import { db } from "@/lib/firebase";
-import { useUser } from "@/components/hooks/UserContext";
 
 type FRQTestRendererProps = {
   frq: Record<string, unknown> | null;
@@ -254,13 +254,15 @@ const FRQTestRenderer = ({
     }
 
     setSubmitting(true);
+
     try {
-      await addDoc(collection(db, "gradableFrqSubmissions"), {
+      await addDoc(getUngradedFrqsCollectionRef(), {
         templateId,
         studentId: user.uid,
         responses,
         submittedAt: serverTimestamp(),
       });
+
       setShowSubmissionModal(false);
       window.alert("Your FRQ was submitted for grading.");
     } catch (submissionError) {

--- a/src/lib/firestore/frqRefs.ts
+++ b/src/lib/firestore/frqRefs.ts
@@ -1,0 +1,42 @@
+import { collection, doc } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+
+export const getFrqTemplatesCollectionRef = (
+  subjectSlug: string,
+  unitId: string,
+) =>
+  collection(
+    db,
+    "subjects",
+    subjectSlug,
+    "units",
+    unitId,
+    "frqs",
+  );
+
+export const getFrqTemplateDocRef = (
+  subjectSlug: string,
+  unitId: string,
+  frqId: string,
+) =>
+  doc(
+    db,
+    "subjects",
+    subjectSlug,
+    "units",
+    unitId,
+    "frqs",
+    frqId,
+  );
+
+export const getUngradedFrqsCollectionRef = () =>
+  collection(db, "ungraded-frqs");
+
+export const getUngradedFrqDocRef = (submissionId: string) =>
+  doc(db, "ungraded-frqs", submissionId);
+
+export const getGradedFrqsCollectionRef = () =>
+  collection(db, "graded-frqs");
+
+export const getGradedFrqDocRef = (submissionId: string) =>
+  doc(db, "graded-frqs", submissionId);

--- a/src/types/frq.ts
+++ b/src/types/frq.ts
@@ -24,6 +24,8 @@ export interface FRQTemplateQuestion {
 export interface GradableFRQSubmission {
   id?: string;
   templateId: string;
+  subject: string;
+  unitId: string;
   studentId: string;
   /** Responses are keyed by a stable FRQTemplateQuestion.id. */
   responses: Record<string, string>;


### PR DESCRIPTION
# Description

Fixes FRQ Firestore collection paths across the site.

FRQ templates are now consistently stored and loaded from:

`subjects/{subjectSlug}/units/{unitId}/frqs/{frqId}`

Student submissions are now stored in:

`ungraded-frqs/{submissionId}`

Completed grading results are now stored in:

`graded-frqs/{submissionId}`

This change also adds shared Firestore reference helpers so the collection paths are defined in one place and reused across the admin subject page, FRQ editor, testing page, grading flow, feedback page, and admin dashboard.

The existing grading transaction is preserved so creating the graded document and deleting the ungraded document happen atomically.

# Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


# How Has This Been Tested? How can the reviewer test it?

1. Start the Firebase emulators and local application.
2. Sign in with an admin account.
3. Open an admin subject page, such as:
   `/admin/subject/calculus-ab`
4. Expand a unit and create a new FRQ.
5. Verify the new document is created at:
   `subjects/calculus-ab/units/{unitId}/frqs/{frqId}`
6. Confirm no top-level `frqTemplates` document is created.
7. Rename the FRQ and toggle its public status.
8. Refresh the page and confirm both changes persist.
9. Open the FRQ editor and confirm it loads the correct nested template.
10. Open the regular subject page and confirm the FRQ is displayed from the unit’s `frqs` collection.
11. Submit a valid FRQ test and verify the submission is created in:
    `ungraded-frqs`
12. Confirm the admin dashboard and grading list load submissions from `ungraded-frqs`.
13. Complete grading and verify:
    - the document is removed from `ungraded-frqs`
    - a matching document is created in `graded-frqs`
14. Open the feedback route and confirm it looks for the result in `graded-frqs`.

Validation completed:

- `npx tsc --noEmit`
- `npm run lint`
- `git diff --check`
- Confirmed no remaining references to:
  - `frqTemplates`
  - `gradableFrqSubmissions`
  - `gradedFrqSubmissions`

The FRQ question-authoring UI is still marked as WIP, so a newly created empty template cannot complete the full student testing flow until valid questions exist. That functionality is outside the scope of this PR.

# Checklist

- [x] I have performed a self-review of my own code
