### PR TITLE
Fix undefined centerImage crashing article saves with images

### DIFF
--- a/src/components/article-creator/Editor.tsx
+++ b/src/components/article-creator/Editor.tsx
@@ -242,7 +242,12 @@ class CustomImage extends Image {
       withBorder: d.withBorder,
       withBackground: d.withBackground,
       stretched: d.stretched,
-      centerImage: d.centerImage,
+      // `centerImage` is a custom action, not one of @editorjs/image's built-in
+      // tunes, so the base tool never initializes it — it stays `undefined`
+      // until the author toggles "Center image" at least once. Firestore's
+      // setDoc() rejects any field with a literal `undefined` value, so this
+      // must be coerced to a boolean before saving.
+      centerImage: d.centerImage ?? false,
     };
   }
 


### PR DESCRIPTION
# Description

Fixes the "ERROR SAVING ARTICLE: FirebaseError: [code=invalid-argument]: Function setDoc called with invalid data. Unsupported field value: undefined" bug that many users hit when saving an article containing an image.

**Root cause:** `CustomImage.save()` in `src/components/article-creator/Editor.tsx` returns `centerImage: d.centerImage`. `centerImage` is a custom action bolted onto the `@editorjs/image` tool (via `config.actions`), not one of the tool's built-in tunes (`withBorder`, `withBackground`, `stretched`). The base tool auto-initializes its built-in tunes to `false`, but has no knowledge of `centerImage`, so it stays a literal `undefined` on `_data` until an author explicitly clicks the "Center image" toggle at least once.

That `undefined` then flows straight into the article's block data and gets written with `setDoc()`. Firestore's client SDK rejects any field holding a literal `undefined` (this project doesn't set `ignoreUndefinedProperties`), which is exactly the reported error. Since most authors never bother toggling "center image" on every image, this affects the large majority of articles containing images.

**Fix:** coerce the value to a boolean before saving, the same way the built-in tunes already resolve to booleans:

```ts
centerImage: d.centerImage ?? false,
```

This is a small, isolated fix — no other behavior changes.

Not tied to any other open PR/issue; found and fixed while investigating a live bug report on fivehive.org.

# Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

# Demo

No visual/UI change — this only affects what gets written to Firestore, not the editor UI or rendering.

# How Has This Been Tested? How can the reviewer test it?

**How it was tested:**
- Read the installed `@editorjs/image@2.10.3` source to confirm the base tool only auto-initializes `withBorder`, `withBackground`, and `stretched` to booleans, never `centerImage` (which this repo adds separately as a custom action).
- Wrote a standalone script that builds the same block-shaped object `CustomImage.save()` produces (with `centerImage: undefined`) and called the real `firebase/firestore` `setDoc()` against it directly — it threw the exact same error reported in production, including the same document-path format. Re-ran after applying the `?? false` fix and confirmed `setDoc()` passed local validation instead of throwing immediately.
- Ran `tsc --noEmit` — no type errors.
- Ran `npm run build` (`next build`) — succeeds, only pre-existing unrelated lint warnings.

**How a reviewer can test it:**
1. Open the article editor for any chapter, add an image block, upload/paste an image, and save **without** toggling the "Center image" setting.
2. On `main` (before this fix), this reliably reproduces the `ERROR SAVING ARTICLE` alert with the `Unsupported field value: undefined` message.
3. With this fix applied, the save succeeds normally regardless of whether "Center image" was ever toggled.

# Checklist

- [x] I have performed a self-review of my own code
