### PR TITLE
fix completion page to show test results

### DIFF
--- a/src/components/questions/digital-testing/CompletionPage.tsx
+++ b/src/components/questions/digital-testing/CompletionPage.tsx
@@ -2,7 +2,6 @@
 
 import { ConfettiExplosion } from "react-confetti-explosion";
 import Image from "next/image";
-import { useRouter, usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 
 const congratulationsMessages = [
@@ -13,9 +12,11 @@ const congratulationsMessages = [
   "You crushed it!",
 ];
 
-export default function CompletionPage() {
-  const router = useRouter();
-  const pathname = usePathname() ?? "";
+interface CompletionPageProps {
+  onContinue: () => void;
+}
+
+export default function CompletionPage({ onContinue }: CompletionPageProps) {
   const [message, setMessage] = useState(congratulationsMessages[0]);
 
   useEffect(() => {
@@ -25,10 +26,6 @@ export default function CompletionPage() {
       ] ?? congratulationsMessages[0],
     );
   }, []);
-
-  const handleContinue = () => {
-    router.push(pathname.split("/").slice(0, 3).join("/"));
-  };
 
   return (
     <main className="relative flex min-h-screen items-center justify-center overflow-hidden bg-[#f7f8fc] px-5 py-10 text-center">
@@ -58,7 +55,7 @@ export default function CompletionPage() {
         />
         <button
           type="button"
-          onClick={handleContinue}
+          onClick={onContinue}
           className="w-full max-w-xs rounded-full bg-[#294ad1] px-8 py-3 text-lg font-bold text-white shadow-sm transition-colors hover:bg-[#203da9] focus:outline-none focus:ring-4 focus:ring-[#294ad1]/30"
         >
           Continue

--- a/src/components/questions/digital-testing/Footer.tsx
+++ b/src/components/questions/digital-testing/Footer.tsx
@@ -132,13 +132,13 @@ export default function Footer({
           className="ml-3 rounded-full bg-[#294ad1] px-6 py-2 font-bold text-white hover:bg-[#2a47bb]"
           onClick={handleNext}
         >
-          {currentQuestionIndex === questions.length - 1
-            ? showReviewPage
-              ? submitted
-                ? "Exit"
-                : "Submit"
-              : "Review"
-            : "Next"}
+          {showReviewPage
+            ? submitted
+              ? "Exit"
+              : "Submit"
+            : currentQuestionIndex === questions.length - 1
+              ? "Review"
+              : "Next"}
         </button>
       </div>
     </footer>

--- a/src/components/questions/testRenderer.tsx
+++ b/src/components/questions/testRenderer.tsx
@@ -85,10 +85,16 @@ export default function DigitalTestingPage({
   const [showEliminationTools, setShowEliminationTools] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const [showReviewPage, setShowReviewPage] = useState(false);
+  const [showCompletionPage, setShowCompletionPage] = useState(false);
 
   useEffect(() => {
     setQuestions(inputQuestions);
   }, [inputQuestions]);
+
+  const handleSetSubmitted = (value: boolean) => {
+    setSubmitted(value);
+    if (value && !adminMode) setShowCompletionPage(true);
+  };
 
   // Track highlights for all --- uses index as key to corrospond to question, and array to hold highlights (might need to move to Highlighter file)
   const handleContentHighlights = (newHighlights: Highlight[]) => {
@@ -121,19 +127,26 @@ export default function DigitalTestingPage({
     }));
   };
 
-  if (submitted && !adminMode) {
-    return <CompletionPage />;
+  if (showCompletionPage && !adminMode) {
+    return (
+      <CompletionPage
+        onContinue={() => {
+          setShowCompletionPage(false);
+          setShowReviewPage(true);
+        }}
+      />
+    );
   }
 
   return (
     <div className="flex flex-col">
       {!adminMode && (
-        <Header
-          setSubmitted={setSubmitted}
-          submitted={submitted}
-          timeRemaining={time * 60}
-          directions={directions}
-        />
+          <Header
+            setSubmitted={handleSetSubmitted}
+            submitted={submitted}
+            timeRemaining={time * 60}
+            directions={directions}
+          />
       )}
       {showReviewPage ? (
         <ReviewPage
@@ -274,7 +287,7 @@ export default function DigitalTestingPage({
         selectedAnswers={selectedAnswers}
         setShowReviewPage={setShowReviewPage}
         showReviewPage={showReviewPage}
-        setSubmitted={setSubmitted}
+        setSubmitted={handleSetSubmitted}
         submitted={submitted}
         adminMode={adminMode}
         testName={testName}

--- a/src/components/questions/testRenderer.tsx
+++ b/src/components/questions/testRenderer.tsx
@@ -92,6 +92,10 @@ export default function DigitalTestingPage({
   }, [inputQuestions]);
 
   const handleSetSubmitted = (value: boolean) => {
+    // Header unmounts while the completion page is up, so continuing on to the
+    // results remounts it with a fresh countdown. Ignore repeat submits so that
+    // restarted timer can't drag the user back to the completion page.
+    if (value && submitted) return;
     setSubmitted(value);
     if (value && !adminMode) setShowCompletionPage(true);
   };
@@ -141,12 +145,12 @@ export default function DigitalTestingPage({
   return (
     <div className="flex flex-col">
       {!adminMode && (
-          <Header
-            setSubmitted={handleSetSubmitted}
-            submitted={submitted}
-            timeRemaining={time * 60}
-            directions={directions}
-          />
+        <Header
+          setSubmitted={handleSetSubmitted}
+          submitted={submitted}
+          timeRemaining={time * 60}
+          directions={directions}
+        />
       )}
       {showReviewPage ? (
         <ReviewPage


### PR DESCRIPTION
# Description
right now, the completion page's continue page goes to home screen instead of viewing results. After the pr, it should go to the results screen

# Pull request type
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

# Checklist
- [x] I have performed a self-review of my own code
