### PR TITLE
FRQ 2/3: point grading at the collection submissions are actually written to

### DIFF
--- a/src/app/frq-grading/[id]/page.tsx
+++ b/src/app/frq-grading/[id]/page.tsx
@@ -1,8 +1,13 @@
 "use client";
 
 import FRQGradingRenderer from "@/components/frq/gradingRenderer";
-import { getUngradedFrqDocRef } from "@/lib/firestore/frqRefs";
-import type { GradableFRQSubmission } from "@/types/frq";
+import { useUser } from "@/components/hooks/UserContext";
+import {
+  getFrqTemplateDocRef,
+  getUngradedFrqDocRef,
+} from "@/lib/firestore/frqRefs";
+import { normalizeFrqTemplate } from "@/lib/frq/template";
+import type { FRQTemplate, GradableFRQSubmission } from "@/types/frq";
 import { getDoc } from "firebase/firestore";
 import { useEffect, useState } from "react";
 
@@ -13,39 +18,100 @@ type PageProps = {
 };
 
 const Page = ({ params }: PageProps) => {
-  const [frq, setFrq] = useState<GradableFRQSubmission | null>(null);
+  const { user, loading: userLoading } = useUser();
+
+  const [submission, setSubmission] = useState<GradableFRQSubmission | null>(
+    null,
+  );
+  const [template, setTemplate] = useState<FRQTemplate | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const canGrade = user?.access === "admin" || user?.access === "grader";
 
   useEffect(() => {
-    const fetchFrq = async () => {
-      try {
-        const docRef = getUngradedFrqDocRef(params.id);
-        const docSnap = await getDoc(docRef);
+    if (userLoading || !canGrade) {
+      if (!userLoading) {
+        setIsLoading(false);
+      }
+      return;
+    }
 
-        if (docSnap.exists()) {
-          setFrq({
-            id: docSnap.id,
-            ...(docSnap.data() as GradableFRQSubmission),
-          });
-        } else {
-          setFrq(null);
+    const fetchSubmissionAndTemplate = async () => {
+      setIsLoading(true);
+      setLoadError(null);
+
+      try {
+        const submissionSnapshot = await getDoc(
+          getUngradedFrqDocRef(params.id),
+        );
+
+        if (!submissionSnapshot.exists()) {
+          setLoadError(
+            "This submission is no longer in the queue. It may already have been graded.",
+          );
+          return;
         }
+
+        const loadedSubmission = {
+          id: submissionSnapshot.id,
+          ...(submissionSnapshot.data() as Omit<GradableFRQSubmission, "id">),
+        };
+
+        setSubmission(loadedSubmission);
+
+        // The rubric being graded against lives on the template, not on the
+        // submission, so both have to be in hand before grading can start.
+        const templateSnapshot = await getDoc(
+          getFrqTemplateDocRef(
+            loadedSubmission.subject,
+            loadedSubmission.unitId,
+            loadedSubmission.templateId,
+          ),
+        );
+
+        setTemplate(
+          templateSnapshot.exists()
+            ? normalizeFrqTemplate(templateSnapshot.data(), {
+                id: templateSnapshot.id,
+                subject: loadedSubmission.subject,
+                unitId: loadedSubmission.unitId,
+              })
+            : null,
+        );
       } catch (error) {
-        console.error("Error fetching FRQ:", error);
-        setFrq(null);
+        console.error("Error loading FRQ submission:", error);
+
+        setLoadError(
+          error instanceof Error
+            ? `Could not load this submission: ${error.message}`
+            : "Could not load this submission.",
+        );
       } finally {
         setIsLoading(false);
       }
     };
 
-    void fetchFrq();
-  }, [params.id]);
+    void fetchSubmissionAndTemplate();
+  }, [params.id, userLoading, canGrade]);
 
-  if (isLoading) {
-    return <div>Loading...</div>;
+  if (userLoading || isLoading) {
+    return <div className="p-8">Loading...</div>;
   }
 
-  return <FRQGradingRenderer frq={frq} />;
+  if (!canGrade) {
+    return (
+      <div className="p-8">
+        You need grader or admin access to grade FRQ submissions.
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return <div className="p-8">{loadError}</div>;
+  }
+
+  return <FRQGradingRenderer submission={submission} template={template} />;
 };
 
 export default Page;

--- a/src/app/frq-grading/page.tsx
+++ b/src/app/frq-grading/page.tsx
@@ -3,8 +3,13 @@
 import Navbar from "@/components/global/navbar";
 import Footer from "@/components/global/footer";
 import Link from "next/link";
-import { db } from "@/lib/firebase";
-import { deleteDoc, collection, doc, getDoc, getCountFromServer, getDocs, limit, orderBy, query, startAfter, type DocumentData, type QueryDocumentSnapshot, Timestamp } from "firebase/firestore";
+import { useUser } from "@/components/hooks/UserContext";
+import {
+  getFrqTemplateDocRef,
+  getUngradedFrqDocRef,
+  getUngradedFrqsCollectionRef,
+} from "@/lib/firestore/frqRefs";
+import { deleteDoc, getDoc, getCountFromServer, getDocs, limit, orderBy, query, startAfter, type DocumentData, type QueryDocumentSnapshot, Timestamp } from "firebase/firestore";
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Trash2, ChevronLeft, ChevronRight } from "lucide-react";
@@ -28,6 +33,12 @@ type PageCursor =
   QueryDocumentSnapshot<DocumentData> | null;
 
 const Page = () => {
+  const { user, loading: userLoading } = useUser();
+
+  // Firestore rules already reject a non-grader's reads, but without this check
+  // the page renders a full, permanently empty queue and gives no hint why.
+  const canGrade = user?.access === "admin" || user?.access === "grader";
+
   const [frqs, setFrqs] = useState<UngradedFrqRow[] | null>(null);
 
   const [frqToDelete, setFrqToDelete] = useState<UngradedFrqRow | null>(null);
@@ -54,10 +65,11 @@ const Page = () => {
     const fetchFrqs = useCallback(async (cursor: PageCursor) => {
       setIsPageLoading(true);
       try {
-        const collectionRef = collection(
-          db,
-          "gradableFrqSubmissions",
-        );
+        // `ungraded-frqs` is the collection the student test actually writes to.
+        // This page previously read `gradableFrqSubmissions`, a name from an
+        // earlier schema pass that nothing has written to since, so the queue
+        // read as permanently empty no matter how many tests were submitted.
+        const collectionRef = getUngradedFrqsCollectionRef();
 
       const pageQuery = cursor
         ? query(
@@ -107,20 +119,27 @@ const Page = () => {
               )
             : {};
 
+          // A submission records where its template lives, so the location no
+          // longer has to be recovered from a flat template collection.
+          const subject =
+            typeof rawData.subject === "string" ? rawData.subject : "";
+          const unitId =
+            typeof rawData.unitId === "string" ? rawData.unitId : "";
+
           let isMalformed =
             templateId === "" ||
             studentId === "" ||
+            subject === "" ||
+            unitId === "" ||
             submittedAt === null ||
             !hasValidResponses;
-          
-          let frqTitle = "Unknown FRQ";
-          let subject = "Unknown subject";
-          let unitId = "Unknown unit";
 
-          if (templateId !== "") {
+          let frqTitle = "Unknown FRQ";
+
+          if (!isMalformed) {
             try {
               const templateSnapshot = await getDoc(
-                doc(db, "frqTemplates", templateId),
+                getFrqTemplateDocRef(subject, unitId, templateId),
               );
 
               if (templateSnapshot.exists()) {
@@ -128,18 +147,6 @@ const Page = () => {
 
                 if (typeof templateData.title === "string") {
                   frqTitle = templateData.title;
-                } else {
-                  isMalformed = true;
-                }
-
-                if (typeof templateData.subject === "string") {
-                  subject = templateData.subject;
-                } else {
-                  isMalformed = true;
-                }
-
-                if (typeof templateData.unitId === "string") {
-                  unitId = templateData.unitId;
                 } else {
                   isMalformed = true;
                 }
@@ -163,8 +170,8 @@ const Page = () => {
             responses,
             isMalformed,
             frqTitle,
-            subject,
-            unitId
+            subject: subject || "Unknown subject",
+            unitId: unitId || "Unknown unit",
           };
         }),
       );
@@ -179,9 +186,13 @@ const Page = () => {
 
 
     useEffect(() => {
+      if (userLoading || !canGrade) {
+        return;
+      }
+
       const initializePage = async () => {
         const countSnapshot = await getCountFromServer(
-          collection(db, "gradableFrqSubmissions"),
+          getUngradedFrqsCollectionRef(),
         );
 
         setTotalCount(countSnapshot.data().count);
@@ -195,7 +206,7 @@ const Page = () => {
         );
         setFrqs([]);
       });
-    }, [fetchFrqs]);
+    }, [fetchFrqs, userLoading, canGrade]);
 
 
 const handleNextPage = async () => {
@@ -239,8 +250,7 @@ const handlePreviousPage = async () => {
     setIsDeleting(true);
 
     try {
-      await deleteDoc(
-        doc(db, "gradableFrqSubmissions", frqToDelete.id));
+      await deleteDoc(getUngradedFrqDocRef(frqToDelete.id));
 
       setFrqs((currentFrqs) =>
         currentFrqs
@@ -270,8 +280,28 @@ const handlePreviousPage = async () => {
     }
   };
 
+  if (userLoading) {
+    return <div className="p-8">Loading...</div>;
+  }
+
+  if (!canGrade) {
+    return (
+      <div className="flex min-h-screen flex-col">
+        <Navbar />
+        <main className="mx-auto mt-12 w-full max-w-6xl flex-1 px-8 pb-8">
+          <h1 className="text-4xl font-bold">Grader access required</h1>
+          <p className="mt-4 text-gray-600">
+            Ask an admin to grant your account grader access to review FRQ
+            submissions.
+          </p>
+        </main>
+        <Footer className="w-full" />
+      </div>
+    );
+  }
+
   if (frqs === null) {
-    return <div>Loading...</div>;
+    return <div className="p-8">Loading...</div>;
   }
 
   return (

--- a/src/components/frq/gradingRenderer.tsx
+++ b/src/components/frq/gradingRenderer.tsx
@@ -1,15 +1,10 @@
 "use client";
 
+import { RenderContent } from "@/components/article-creator/custom_questions/RenderAdvancedTextbox";
 import { db } from "@/lib/firebase";
-import { useState, type ReactNode } from "react";
+import { useMemo, useState } from "react";
 import Link from "next/link";
-import {
-  ChevronDown,
-  ChevronLeft,
-  ChevronRight,
-  ChevronUp,
-  LogOut,
-} from "lucide-react";
+import { ChevronLeft, ChevronRight, ChevronUp, LogOut } from "lucide-react";
 import { runTransaction, serverTimestamp } from "firebase/firestore";
 import {
   Popover,
@@ -20,75 +15,127 @@ import {
   getGradedFrqDocRef,
   getUngradedFrqDocRef,
 } from "@/lib/firestore/frqRefs";
+import {
+  getPartLabel,
+  getQuestionPoints,
+  getTemplatePoints,
+  toQuestionInput,
+} from "@/lib/frq/template";
 
 import { useUser } from "@/components/hooks/UserContext";
-import type { GradableFRQSubmission } from "@/types/frq";
+import type {
+  FRQTemplate,
+  FRQTemplateQuestion,
+  GradableFRQSubmission,
+} from "@/types/frq";
 
 type FRQGradingRendererProps = {
-  frq: GradableFRQSubmission | null;
+  submission: GradableFRQSubmission | null;
+  template: FRQTemplate | null;
 };
 
-type MockFrq = { title: string; questionCount: number };
-type RubricItem = {
-  description: string;
-  earnedPoints: number;
-  possiblePoints: number;
+/** Points awarded per criterion, and the grader's note, for one part. */
+type PartGrade = {
+  feedback: string;
+  criteria: Record<string, number>;
 };
 
-const MOCK_FRQS: MockFrq[] = [
-  { title: "FRQ 1", questionCount: 3 },
-  { title: "FRQ 2", questionCount: 4 },
-  { title: "FRQ 3", questionCount: 2 },
-];
+const createEmptyGrade = (question: FRQTemplateQuestion): PartGrade => ({
+  feedback: "",
+  criteria: Object.fromEntries(
+    (question.criteria ?? []).map((criterion) => [criterion.id, 0]),
+  ),
+});
 
-const RUBRIC_ITEMS: RubricItem[] = [
-  {
-    description: "Answer draws a connection to the Great Demographic Shift",
-    earnedPoints: 0,
-    possiblePoints: 2,
-  },
-  {
-    description: "Answer mentions John Smith’s contributions",
-    earnedPoints: 0,
-    possiblePoints: 1,
-  },
-  {
-    description: "Answer is at least 27 paragraphs long",
-    earnedPoints: 1,
-    possiblePoints: 1,
-  },
-  {
-    description:
-      "Answer contains correct punctuation, capitalization, and supporting details",
-    earnedPoints: 2,
-    possiblePoints: 2,
-  },
-];
-
-const FRQGradingRenderer = ({ frq }: FRQGradingRendererProps) => {
+const FRQGradingRenderer = ({
+  submission,
+  template,
+}: FRQGradingRendererProps) => {
   const { user } = useUser();
-  const [currentFrqIndex, setCurrentFrqIndex] = useState(0);
+
+  // Grading covers every part the template defines, including ones marked
+  // legacy: an older submission may still hold a response to them.
+  const questions = useMemo(() => template?.questions ?? [], [template]);
+
+  const [currentIndex, setCurrentIndex] = useState(0);
   const [isNavigationOpen, setIsNavigationOpen] = useState(false);
-  const [feedback, setFeedback] = useState("");
-  const [savedFeedback, setSavedFeedback] = useState("");
+  const [overallFeedback, setOverallFeedback] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showPrompt, setShowPrompt] = useState(true);
-
-  if (!frq) return <div>FRQ not found.</div>;
-
-  const currentFrq = MOCK_FRQS[currentFrqIndex];
-  if (!currentFrq) return <div>No FRQs available.</div>;
-
-  const earnedPoints = RUBRIC_ITEMS.reduce(
-    (total, item) => total + item.earnedPoints,
-    0,
+  const [grades, setGrades] = useState<Record<string, PartGrade>>(() =>
+    Object.fromEntries(
+      questions.map((question) => [question.id, createEmptyGrade(question)]),
+    ),
   );
-  const possiblePoints = RUBRIC_ITEMS.reduce(
-    (total, item) => total + item.possiblePoints,
-    0,
-  );
+
+  const possiblePoints = getTemplatePoints(questions);
+
+  const earnedPoints = questions.reduce((total, question) => {
+    const partGrade = grades[question.id];
+
+    if (!partGrade) {
+      return total;
+    }
+
+    return (
+      total +
+      (question.criteria ?? []).reduce(
+        (partTotal, criterion) =>
+          partTotal + (partGrade.criteria[criterion.id] ?? 0),
+        0,
+      )
+    );
+  }, 0);
+
+  // A part counts as graded once the grader has written a note for it, which is
+  // the only signal that distinguishes "looked at and awarded zero" from
+  // "not looked at yet".
+  const gradedPartCount = questions.filter((question) =>
+    (grades[question.id]?.feedback ?? "").trim(),
+  ).length;
+
+  const setCriterionPoints = (
+    questionId: string,
+    criterionId: string,
+    rawPoints: number,
+    maximumPoints: number,
+  ) => {
+    const points = Math.min(
+      Math.max(Number.isFinite(rawPoints) ? Math.round(rawPoints) : 0, 0),
+      maximumPoints,
+    );
+
+    setGrades((currentGrades) => ({
+      ...currentGrades,
+      [questionId]: {
+        feedback: currentGrades[questionId]?.feedback ?? "",
+        criteria: {
+          ...(currentGrades[questionId]?.criteria ?? {}),
+          [criterionId]: points,
+        },
+      },
+    }));
+  };
+
+  const setPartFeedback = (questionId: string, feedback: string) => {
+    setGrades((currentGrades) => ({
+      ...currentGrades,
+      [questionId]: {
+        feedback,
+        criteria: currentGrades[questionId]?.criteria ?? {},
+      },
+    }));
+  };
+
   const submitGradeReport = async () => {
-    if (!frq.id || !user || !feedback.trim()) return;
+    if (!submission?.id || !user || !template) {
+      return;
+    }
+
+    if (!overallFeedback.trim()) {
+      window.alert("Add overall feedback before submitting the grade report.");
+      return;
+    }
 
     setIsSubmitting(true);
 
@@ -96,8 +143,8 @@ const FRQGradingRenderer = ({ frq }: FRQGradingRendererProps) => {
       // Use the submission ID as the result ID and atomically claim the queue
       // item. Firestore retries concurrent transactions, so only one grader
       // can successfully issue a report for a submission.
-      const queueRef = getUngradedFrqDocRef(frq.id);
-      const resultRef = getGradedFrqDocRef(frq.id);
+      const queueRef = getUngradedFrqDocRef(submission.id);
+      const resultRef = getGradedFrqDocRef(submission.id);
 
       await runTransaction(db, async (transaction) => {
         const [queueSnapshot, resultSnapshot] = await Promise.all([
@@ -109,22 +156,31 @@ const FRQGradingRenderer = ({ frq }: FRQGradingRendererProps) => {
           throw new Error("This submission has already been graded.");
         }
 
-        const queuedSubmission =
-          queueSnapshot.data() as GradableFRQSubmission;
+        const queuedSubmission = queueSnapshot.data() as GradableFRQSubmission;
 
-          transaction.set(resultRef, {
-            sourceSubmissionId: frq.id,
-            templateId: queuedSubmission.templateId,
-            subject: queuedSubmission.subject,
-            unitId: queuedSubmission.unitId,
-            studentId: queuedSubmission.studentId,
-            responses: queuedSubmission.responses,
-            submittedAt: queuedSubmission.submittedAt,
-            score: `${earnedPoints}/${possiblePoints}`,
-            feedback: feedback.trim(),
-            graderId: user.uid,
-            gradedAt: serverTimestamp(),
-          });
+        transaction.set(resultRef, {
+          sourceSubmissionId: submission.id,
+          templateId: queuedSubmission.templateId,
+          subject: queuedSubmission.subject,
+          unitId: queuedSubmission.unitId,
+          studentId: queuedSubmission.studentId,
+          responses: queuedSubmission.responses,
+          submittedAt: queuedSubmission.submittedAt,
+          score: `${earnedPoints}/${possiblePoints}`,
+          feedback: overallFeedback.trim(),
+          // Per-part detail is what lets the student's feedback page show which
+          // rubric lines were earned instead of a bare aggregate.
+          grades: questions.map((question) => ({
+            questionId: question.id,
+            feedback: grades[question.id]?.feedback?.trim() ?? "",
+            criteria: (question.criteria ?? []).map((criterion) => ({
+              criterionId: criterion.id,
+              points: grades[question.id]?.criteria[criterion.id] ?? 0,
+            })),
+          })),
+          graderId: user.uid,
+          gradedAt: serverTimestamp(),
+        });
 
         transaction.delete(queueRef);
       });
@@ -144,427 +200,289 @@ const FRQGradingRenderer = ({ frq }: FRQGradingRendererProps) => {
     }
   };
 
+  if (!submission) return <div className="p-8">FRQ submission not found.</div>;
+
+  if (!template) {
+    return (
+      <div className="p-8">
+        The FRQ this submission came from no longer exists, so it cannot be
+        graded.
+      </div>
+    );
+  }
+
+  const currentQuestion = questions[currentIndex];
+
+  if (!currentQuestion) {
+    return (
+      <div className="p-8">
+        This FRQ has no questions to grade.
+      </div>
+    );
+  }
+
+  const currentGrade = grades[currentQuestion.id];
+  const currentCriteria = currentQuestion.criteria ?? [];
+  const currentEarned = currentCriteria.reduce(
+    (total, criterion) => total + (currentGrade?.criteria[criterion.id] ?? 0),
+    0,
+  );
+
   return (
     <div className="flex min-h-screen flex-col border-t-[6px] border-black bg-white pb-14">
-      <GradingHeader
-        gradedQuestionCount={5}
-        totalQuestionCount={6}
-        isSubmitting={isSubmitting}
-        onSaveChanges={() => setSavedFeedback(feedback)}
-        onSubmitGradeReport={() => void submitGradeReport()}
-      />
+      <header className="flex min-h-[72px] items-center border-b border-dashed border-gray-400 bg-white px-10 py-3">
+        <div className="flex flex-1 items-center gap-4">
+          <button
+            type="button"
+            disabled={isSubmitting}
+            onClick={() => void submitGradeReport()}
+            className="min-w-[176px] rounded-full bg-[#294ad1] px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#203cad] disabled:opacity-50"
+          >
+            {isSubmitting ? "Submitting..." : "Submit Grade Report"}
+          </button>
+
+          <p className="text-sm font-semibold tabular-nums">
+            {earnedPoints}/{possiblePoints} points
+          </p>
+        </div>
+
+        <div className="flex flex-1 justify-center">
+          <p className="text-sm font-semibold text-gray-900">
+            {gradedPartCount}/{questions.length} Questions Graded
+          </p>
+        </div>
+
+        <div className="flex flex-1 justify-end">
+          <Link
+            href="/frq-grading"
+            className="flex items-center gap-2 text-sm font-semibold text-red-500 transition-colors hover:text-red-600 hover:underline"
+          >
+            <LogOut aria-hidden="true" size={19} strokeWidth={2} />
+            Return To Grading Queue
+          </Link>
+        </div>
+      </header>
 
       <main className="grid flex-1 grid-cols-1 divide-y divide-gray-300 lg:grid-cols-2 lg:divide-x lg:divide-y-0">
-        <GraderResponsePanel
-          frqTitle={currentFrq.title}
-          feedback={feedback}
-          savedFeedback={savedFeedback}
-          onFeedbackChange={setFeedback}
-        />
-        <StudentResponsePanel
-          frqTitle={currentFrq.title}
-          questionCount={currentFrq.questionCount}
-          responses={frq.responses}
-          showPrompt={showPrompt}
-          onShowPromptChange={() => setShowPrompt((visible) => !visible)}
-        />
-      </main>
+        <section className="px-10 py-8">
+          <h2 className="mb-5 text-base font-semibold">
+            {template.title} | Part {getPartLabel(currentIndex)} | Grader
+            Response
+          </h2>
 
-      <GradingFooter
-        currentFrqIndex={currentFrqIndex}
-        totalFrqs={MOCK_FRQS.length}
-        isFirstFrq={currentFrqIndex === 0}
-        isLastFrq={currentFrqIndex === MOCK_FRQS.length - 1}
-        isNavigationOpen={isNavigationOpen}
-        onNavigationOpenChange={setIsNavigationOpen}
-        onPrevious={() => setCurrentFrqIndex((index) => Math.max(index - 1, 0))}
-        onNext={() =>
-          setCurrentFrqIndex((index) =>
-            Math.min(index + 1, MOCK_FRQS.length - 1),
-          )
-        }
-        onJumpToFrq={(index) => {
-          if (index >= 0 && index < MOCK_FRQS.length) {
-            setCurrentFrqIndex(index);
-            setIsNavigationOpen(false);
-          }
-        }}
-      />
-    </div>
-  );
-};
+          <div className="mb-3 flex h-9 items-center bg-gray-100 pr-3">
+            <span className="flex h-full w-9 items-center justify-center bg-black font-bold text-white">
+              {getPartLabel(currentIndex)}
+            </span>
+            <span className="px-3 font-semibold tabular-nums">
+              {currentEarned}/{getQuestionPoints(currentQuestion)} Points
+            </span>
+          </div>
 
-function GradingHeader({
-  gradedQuestionCount,
-  totalQuestionCount,
-  isSubmitting,
-  onSaveChanges,
-  onSubmitGradeReport,
-}: {
-  gradedQuestionCount: number;
-  totalQuestionCount: number;
-  isSubmitting: boolean;
-  onSaveChanges: () => void;
-  onSubmitGradeReport: () => void;
-}) {
-  return (
-    <header className="flex min-h-[72px] items-center border-b border-dashed border-gray-400 bg-white px-10 py-3">
-      <div className="flex flex-1 items-center gap-4">
-        <button
-          type="button"
-          disabled={isSubmitting}
-          onClick={onSubmitGradeReport}
-          className="min-w-[176px] rounded-full bg-[#294ad1] px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#203cad] disabled:opacity-50"
-        >
-          {isSubmitting ? "Submitting..." : "Submit Grade Report"}
-        </button>
-        <button
-          type="button"
-          onClick={onSaveChanges}
-          className="min-w-[176px] rounded-full bg-[#294ad1] px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#203cad]"
-        >
-          Save Changes
-        </button>
-      </div>
-      <div className="flex flex-1 justify-center">
-        <p className="text-sm font-semibold text-gray-900">
-          {gradedQuestionCount}/{totalQuestionCount} Questions Graded
-        </p>
-      </div>
-      <div className="flex flex-1 justify-end">
-        <Link
-          href="/admin"
-          className="flex items-center gap-2 text-sm font-semibold text-red-500 transition-colors hover:text-red-600 hover:underline"
-        >
-          <LogOut aria-hidden="true" size={19} strokeWidth={2} />
-          Return To Admin Dashboard
-        </Link>
-      </div>
-    </header>
-  );
-}
+          <div className="space-y-1">
+            {currentCriteria.length === 0 ? (
+              <p className="rounded-md border border-dashed p-4 text-sm text-gray-500">
+                This part has no grading criteria, so it is worth zero points.
+                Add criteria in the FRQ editor.
+              </p>
+            ) : (
+              currentCriteria.map((criterion) => (
+                <div
+                  key={criterion.id}
+                  className="flex min-h-9 items-center gap-2"
+                >
+                  <div className="min-w-0 flex-1 rounded-md border border-gray-300 px-3 py-1.5 text-sm">
+                    <span className="block">
+                      {criterion.description || "Untitled criterion"}
+                    </span>
+                  </div>
 
-function GraderResponsePanel({
-  frqTitle,
-  feedback,
-  savedFeedback,
-  onFeedbackChange,
-}: {
-  frqTitle: string;
-  feedback: string;
-  savedFeedback: string;
-  onFeedbackChange: (feedback: string) => void;
-}) {
-  return (
-    <section className="px-10 py-8">
-      <h2 className="mb-5 text-base font-semibold">
-        {frqTitle} | Question A | Grader Response
-      </h2>
-      <QuestionHeader label="A" points="3/6 Points" expanded />
-      <div className="space-y-1">
-        {RUBRIC_ITEMS.map((item) => (
-          <RubricRow key={item.description} item={item} />
-        ))}
-      </div>
-      <div className="mt-4 min-h-[150px] rounded-md border border-gray-300">
-        <div className="flex h-10 items-center gap-3 border-b border-gray-300 px-3 text-sm">
-          <button type="button" className="font-bold">
-            B
-          </button>
-          <button type="button" className="italic">
-            I
-          </button>
-          <button type="button" className="underline">
-            U
-          </button>
-          <span>Ω</span>
-        </div>
-        <textarea
-          aria-label="Grader feedback"
-          value={feedback}
-          placeholder="Grader feedback will be entered here."
-          onChange={(event) => onFeedbackChange(event.target.value)}
-          className="min-h-[110px] w-full resize-y p-3 text-sm outline-none"
-        />
-        {savedFeedback === feedback && feedback && (
-          <p className="px-3 pb-2 text-xs text-green-700">
-            Changes saved locally.
-          </p>
-        )}
-      </div>
-      <QuestionHeader label="B" points="0/3 Points" />
-      <QuestionHeader label="C" points="0/3 Points" />
-    </section>
-  );
-}
+                  <div className="flex shrink-0 items-center gap-1">
+                    <input
+                      type="number"
+                      min={0}
+                      max={criterion.points}
+                      step={1}
+                      aria-label={`Points for ${
+                        criterion.description || "criterion"
+                      }`}
+                      value={currentGrade?.criteria[criterion.id] ?? 0}
+                      onChange={(event) =>
+                        setCriterionPoints(
+                          currentQuestion.id,
+                          criterion.id,
+                          Number(event.target.value),
+                          criterion.points,
+                        )
+                      }
+                      className="h-8 w-16 rounded-md border border-gray-300 px-2 text-center"
+                    />
+                    <span>/</span>
+                    <span className="tabular-nums">{criterion.points}</span>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
 
-type RubricRowProps = {
-  item: RubricItem;
-};
+          <div className="mt-4">
+            <label
+              htmlFor="part-feedback"
+              className="text-sm font-semibold"
+            >
+              Feedback for part {getPartLabel(currentIndex)}
+            </label>
+            <textarea
+              id="part-feedback"
+              value={currentGrade?.feedback ?? ""}
+              placeholder="Explain what this part earned and what was missing."
+              onChange={(event) =>
+                setPartFeedback(currentQuestion.id, event.target.value)
+              }
+              className="mt-2 min-h-[110px] w-full resize-y rounded-md border border-gray-300 p-3 text-sm outline-none"
+            />
+          </div>
 
-function RubricRow({ item }: RubricRowProps) {
-  return (
-    <div className="flex min-h-9 items-center gap-2">
-      <div className="min-w-0 flex-1 rounded-md border border-gray-300 px-3 py-1.5 text-sm">
-        <span className="block truncate">{item.description}</span>
-      </div>
-      <div className="flex shrink-0 items-center gap-1">
-        <span className="flex h-8 min-w-8 items-center justify-center rounded-md border border-gray-300 px-2">
-          {item.earnedPoints}
-        </span>
-        <span>/</span>
-        <span>{item.possiblePoints}</span>
-      </div>
-    </div>
-  );
-}
+          <div className="mt-6">
+            <label
+              htmlFor="overall-feedback"
+              className="text-sm font-semibold"
+            >
+              Overall feedback
+            </label>
+            <textarea
+              id="overall-feedback"
+              value={overallFeedback}
+              placeholder="Summarize the response as a whole. Required to submit."
+              onChange={(event) => setOverallFeedback(event.target.value)}
+              className="mt-2 min-h-[110px] w-full resize-y rounded-md border border-gray-300 p-3 text-sm outline-none"
+            />
+          </div>
+        </section>
 
-function StudentResponsePanel({
-  frqTitle,
-  questionCount,
-  responses,
-  showPrompt,
-  onShowPromptChange,
-}: {
-  frqTitle: string;
-  questionCount: number;
-  responses: Record<string, string>;
-  showPrompt: boolean;
-  onShowPromptChange: () => void;
-}) {
-  return (
-    <section className="px-10 py-8">
-      <div className="mb-4 flex items-center justify-between">
-        <h2 className="text-base font-semibold">
-          {frqTitle} | {questionCount} Questions
-        </h2>
+        <section className="px-10 py-8">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-base font-semibold">
+              {template.title} | {questions.length}{" "}
+              {questions.length === 1 ? "Question" : "Questions"}
+            </h2>
 
-        <button
-          type="button"
-          className="rounded-md bg-black px-5 py-2 text-sm font-semibold text-white transition-colors hover:bg-gray-800"
-        >
-          Show Prompt
-        </button>
-      </div>
-
-      <QuestionHeader label="A" expanded />
-
-      <div className="mb-5 text-sm leading-6 text-gray-900">
-        <p className="mb-4">
-          The demographic transition model can be used to theorize changes in a
-          country&apos;s total population over time.
-        </p>
-
-        <p className="mb-3 font-medium">
-          Respond to parts A, B, C, D, E, F, and G.
-        </p>
-
-        <ol className="space-y-2">
-          <li>
-            <strong>A.</strong> Referring to Figure 1, identify the stage of the
-            Demographic Transition Model that this country is most likely in.
-          </li>
-
-          <li>
-            <strong>B.</strong> Explain one social cause of the transition
-            between Stage 2 and Stage 3.
-          </li>
-
-          <li>
-            <strong>C.</strong> Define the term pro-natalist policy.
-          </li>
-
-          <li>
-            <strong>D.</strong> Explain the change in cause of death between
-            Stage 3 and Stage 4.
-          </li>
-        </ol>
-      </div>
-
-      <div className="min-h-[260px] rounded-md border border-gray-400 p-4 text-sm leading-6">
-        <p className="mb-4">
-          This is temporary student response content used to match the
-          grading-page mockup. The actual FRQ response will be loaded in a
-          future work item.
-        </p>
-
-        <p className="mb-4">
-          The student response area will use the advanced textbox renderer after
-          its required properties are confirmed.
-        </p>
-
-        <p>
-          Navigating through the footer changes the displayed FRQ title and
-          question count.
-        </p>
-
-        {/*
-          Replace this temporary content with RenderAdvancedTextbox.
-        */}
-      </div>
-
-      <QuestionHeader label="B" />
-      <QuestionHeader label="C" />
-    </section>
-  );
-}
-
-function QuestionHeader({
-  label,
-  points,
-  expanded = false,
-}: {
-  label: string;
-  points?: string;
-  expanded?: boolean;
-}) {
-  const Icon = expanded ? ChevronDown : ChevronRight;
-  return (
-    <button
-      type="button"
-      aria-expanded={expanded}
-      className="mb-3 flex h-9 w-full items-center justify-between bg-gray-100 pr-3 text-left"
-    >
-      <div className="flex h-full items-center">
-        <span className="flex h-full w-9 items-center justify-center bg-black font-bold text-white">
-          {label}
-        </span>
-        {points && <span className="px-3 font-semibold">{points}</span>}
-      </div>
-      <Icon aria-hidden="true" className="size-5" />
-    </button>
-  );
-}
-
-type GradingFooterProps = {
-  currentFrqIndex: number;
-  totalFrqs: number;
-  isFirstFrq: boolean;
-  isLastFrq: boolean;
-  isNavigationOpen: boolean;
-  onNavigationOpenChange: (open: boolean) => void;
-  onPrevious: () => void;
-  onNext: () => void;
-  onJumpToFrq: (index: number) => void;
-};
-
-function GradingFooter({
-  currentFrqIndex,
-  totalFrqs,
-  isFirstFrq,
-  isLastFrq,
-  isNavigationOpen,
-  onNavigationOpenChange,
-  onPrevious,
-  onNext,
-  onJumpToFrq,
-}: GradingFooterProps) {
-  return (
-    <footer className="fixed bottom-0 left-0 z-50 flex h-14 w-full items-center justify-between border-t-2 border-gray-300 bg-white px-8">
-      <p className="font-semibold">AP Human Geography Practice FRQ</p>
-
-      <div className="absolute left-1/2 flex -translate-x-1/2 items-center gap-2">
-        <FooterIconButton
-          label="Previous FRQ"
-          disabled={isFirstFrq}
-          onClick={onPrevious}
-        >
-          <ChevronLeft aria-hidden="true" className="size-5" />
-        </FooterIconButton>
-        <Popover open={isNavigationOpen} onOpenChange={onNavigationOpenChange}>
-          <PopoverTrigger asChild>
             <button
               type="button"
-              className="flex items-center gap-1 rounded-md bg-black px-4 py-2 text-sm font-bold text-white transition-colors hover:bg-gray-800"
+              onClick={() => setShowPrompt((visible) => !visible)}
+              className="rounded-md bg-black px-5 py-2 text-sm font-semibold text-white transition-colors hover:bg-gray-800"
             >
-              Question {currentFrqIndex + 1} of {totalFrqs}
-              <ChevronUp aria-hidden="true" className="size-4" />
+              {showPrompt ? "Hide Prompt" : "Show Prompt"}
             </button>
-          </PopoverTrigger>
-          <PopoverContent align="center" side="top" className="w-40 p-2">
-            <div className="flex flex-col gap-2">
-              {Array.from({ length: totalFrqs }, (_, index) => (
-                <button
-                  key={index}
-                  type="button"
-                  onClick={() => onJumpToFrq(index)}
-                  className={`rounded-md px-3 py-2 text-left text-sm transition-colors ${
-                    index === currentFrqIndex
-                      ? "bg-[#294ad1] font-bold text-white"
-                      : "bg-gray-100 hover:bg-gray-200"
-                  }`}
-                >
-                  FRQ {index + 1}
-                </button>
-              ))}
+          </div>
+
+          {showPrompt && (
+            <div className="mb-5 border-b border-gray-200 pb-5 text-sm leading-6 text-gray-900">
+              <RenderContent
+                content={toQuestionInput(
+                  template.directions,
+                  template.directionsFiles,
+                )}
+                origin="question"
+              />
+
+              <div className="mt-4">
+                <RenderContent
+                  content={toQuestionInput(
+                    currentQuestion.prompt,
+                    currentQuestion.promptFiles,
+                  )}
+                  origin="question"
+                />
+              </div>
             </div>
-          </PopoverContent>
-        </Popover>
-        <FooterIconButton
-          label="Next FRQ"
-          disabled={isLastFrq}
-          onClick={onNext}
-        >
-          <ChevronRight aria-hidden="true" className="size-5" />
-        </FooterIconButton>
-      </div>
-      <div className="flex items-center gap-3">
-        <FooterNavigationButton disabled={isFirstFrq} onClick={onPrevious}>
-          Back
-        </FooterNavigationButton>
-        <FooterNavigationButton disabled={isLastFrq} onClick={onNext}>
-          Next
-        </FooterNavigationButton>
-      </div>
-    </footer>
-  );
-}
+          )}
 
-type FooterIconButtonProps = {
-  label: string;
-  disabled: boolean;
-  onClick: () => void;
-  children: React.ReactNode;
+          <h3 className="mb-2 text-sm font-semibold">Student response</h3>
+
+          <div
+            className="min-h-[260px] rounded-md border border-gray-400 p-4 text-sm leading-6 [&_p]:mb-3"
+            // The student response is authored in a contenteditable that
+            // sanitizes on every keystroke and again on submit, so what is
+            // stored is already safe to render.
+            dangerouslySetInnerHTML={{
+              __html:
+                submission.responses[currentQuestion.id] ??
+                "<em>No response submitted for this part.</em>",
+            }}
+          />
+        </section>
+      </main>
+
+      <footer className="fixed bottom-0 left-0 z-50 flex h-14 w-full items-center justify-between border-t-2 border-gray-300 bg-white px-8">
+        <p className="font-semibold">{template.title}</p>
+
+        <div className="absolute left-1/2 flex -translate-x-1/2 items-center gap-2">
+          <button
+            type="button"
+            aria-label="Previous part"
+            disabled={currentIndex === 0}
+            onClick={() => setCurrentIndex((index) => Math.max(index - 1, 0))}
+            className="rounded-md bg-black p-2 text-white transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <ChevronLeft aria-hidden="true" className="size-5" />
+          </button>
+
+          <Popover open={isNavigationOpen} onOpenChange={setIsNavigationOpen}>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                className="flex items-center gap-1 rounded-md bg-black px-4 py-2 text-sm font-bold text-white transition-colors hover:bg-gray-800"
+              >
+                Part {getPartLabel(currentIndex)} of {questions.length}
+                <ChevronUp aria-hidden="true" className="size-4" />
+              </button>
+            </PopoverTrigger>
+
+            <PopoverContent align="center" side="top" className="w-40 p-2">
+              <div className="flex flex-col gap-2">
+                {questions.map((question, index) => (
+                  <button
+                    key={question.id}
+                    type="button"
+                    onClick={() => {
+                      setCurrentIndex(index);
+                      setIsNavigationOpen(false);
+                    }}
+                    className={`rounded-md px-3 py-2 text-left text-sm transition-colors ${
+                      index === currentIndex
+                        ? "bg-[#294ad1] font-bold text-white"
+                        : "bg-gray-100 hover:bg-gray-200"
+                    }`}
+                  >
+                    Part {getPartLabel(index)}
+                  </button>
+                ))}
+              </div>
+            </PopoverContent>
+          </Popover>
+
+          <button
+            type="button"
+            aria-label="Next part"
+            disabled={currentIndex === questions.length - 1}
+            onClick={() =>
+              setCurrentIndex((index) =>
+                Math.min(index + 1, questions.length - 1),
+              )
+            }
+            className="rounded-md bg-black p-2 text-white transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <ChevronRight aria-hidden="true" className="size-5" />
+          </button>
+        </div>
+
+        <p className="text-sm text-gray-600">
+          Student: <span className="font-mono">{submission.studentId}</span>
+        </p>
+      </footer>
+    </div>
+  );
 };
-
-function FooterIconButton({
-  label,
-  disabled,
-  onClick,
-  children,
-}: FooterIconButtonProps) {
-  return (
-    <button
-      type="button"
-      aria-label={label}
-      disabled={disabled}
-      onClick={onClick}
-      className="rounded-md bg-black p-2 text-white transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
-    >
-      {children}
-    </button>
-  );
-}
-
-function FooterNavigationButton({
-  disabled,
-  onClick,
-  children,
-}: {
-  disabled: boolean;
-  onClick: () => void;
-  children: ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      disabled={disabled}
-      onClick={onClick}
-      className="rounded-full bg-[#294ad1] px-6 py-2 font-bold text-white transition-colors hover:bg-[#203cad] disabled:cursor-not-allowed disabled:opacity-40"
-    >
-      {children}
-    </button>
-  );
-}
 
 export default FRQGradingRenderer;


### PR DESCRIPTION
Second of three PRs splitting the FRQ end-to-end fixes.

**Based on `frq-1-data-model-and-authoring` (#379), not on `frq`.** The diff shown here is only this PR's 3 files. Independent of PR 3 — the two touch no files in common, so they can be reviewed in parallel.

## Why

The grading queue read a collection called `gradableFrqSubmissions`. Nothing writes to that name — it is left over from an earlier schema pass. The student test writes to `ungraded-frqs`. So the grading queue was **permanently empty no matter how many tests students submitted**, and the grader view rendered mock data rather than the submission being graded.

## What changed

- **`frq-grading` list**: read `ungraded-frqs`, the collection the student test actually writes to, and resolve templates through their real nested location (`subjects/.../units/.../frqs`) instead of a flat `frqTemplates` collection
- **`frq-grading` list**: gate on grader/admin access. Firestore rules already reject a non-grader's reads, but without the check the page rendered a full, permanently empty queue with no hint why
- **`frq-grading/[id]`**: load the real submission and its template
- **`gradingRenderer`**: score against the template's rubric and write grades back, replacing the mock content

## Depends on PR 1

`gradingRenderer` imports `src/lib/frq/template.ts` and needs the `criteria` field, both introduced in #379. This branch does not compile against `frq` alone. The `grades` key and `graded-frqs` rule it relies on also ship in #379.

## Caveats

- The grader UI is verified at the data layer (11/11 checks) but was **not** walked through visually end to end.
- The cookie-consent banner covering the FRQ fixed footers is a known, pre-existing, app-wide blocker left out of scope — see #379 for detail.

## Verification

- `npx tsc --noEmit` passes on this branch
- `npm run build` passes on this branch
