### PR TITLE
FRQ PR 1: nested question/part data model

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "start": "next start",
     "emulate": "firebase emulators:start --import emulator --export-on-exit",
-    "deploy:rules": "firebase deploy --only firestore:rules,firestore:indexes"
+    "deploy:rules": "firebase deploy --only firestore:rules,firestore:indexes",
+    "test": "node --test --experimental-strip-types \"scripts/*.test.ts\""
   },
   "dependencies": {
     "@editorjs/attaches": "^1.3.0",

--- a/scripts/frq-roundtrip.test.ts
+++ b/scripts/frq-roundtrip.test.ts
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  LEGACY_QUESTION_ID,
+  getAllParts,
+  getPartLabel,
+  normalizeFrqTemplate,
+} from "../src/lib/frq/template.ts";
+
+const identity = { id: "t1", subject: "calc", unitId: "u1" };
+
+/**
+ * Mirrors buildTemplatePayload in editorRenderer.tsx: the editor holds a flat
+ * part list and writes it back wrapped in one question. Kept in step with that
+ * function by shape, so this exercises the real save format.
+ */
+const simulateEditorSave = (
+  template: ReturnType<typeof normalizeFrqTemplate>,
+) => ({
+  title: template.title,
+  directions: template.directions,
+  directionsFiles: template.directionsFiles,
+  timeLimitMinutes: template.timeLimitMinutes,
+  isPublic: template.isPublic,
+  questions: [
+    {
+      id: LEGACY_QUESTION_ID,
+      stimulus: "",
+      stimulusFiles: [],
+      parts: getAllParts(template).map((part, index) => ({
+        id: part.id,
+        title: getPartLabel(index),
+        prompt: part.prompt,
+        promptFiles: part.promptFiles,
+        answerType: part.answerType,
+        status: part.status,
+        criteria: part.criteria,
+      })),
+    },
+  ],
+});
+
+// A realistic pre-migration document: flat parts, stimulus in `directions`,
+// mixed statuses, real criteria.
+const legacyDocument = {
+  title: "Unit 3 FRQ",
+  directions: "<p>The graph shows velocity over time.</p>",
+  directionsFiles: [{ key: "graph.png", name: "graph.png" }],
+  timeLimitMinutes: 45,
+  isPublic: true,
+  questions: [
+    {
+      id: "part-abc123",
+      title: "A",
+      prompt: "<p>Find the acceleration.</p>",
+      answerType: "text",
+      status: "public",
+      criteria: [{ id: "crit-1", description: "Correct value", points: 2 }],
+    },
+    {
+      id: "part-def456",
+      title: "B",
+      prompt: "<p>Justify your answer.</p>",
+      answerType: "equation",
+      status: "public",
+      criteria: [{ id: "crit-2", description: "Valid reasoning", points: 3 }],
+    },
+    {
+      id: "part-ghi789",
+      title: "C",
+      prompt: "<p>Retired part.</p>",
+      status: "legacy",
+      criteria: [],
+    },
+  ],
+};
+
+test("round trip: a legacy document survives load -> save -> reload", () => {
+  const loaded = normalizeFrqTemplate(legacyDocument, identity);
+  const reloaded = normalizeFrqTemplate(simulateEditorSave(loaded), identity);
+
+  const before = getAllParts(loaded);
+  const after = getAllParts(reloaded);
+
+  // The property existing submissions and grades depend on: every part id
+  // survives a save unchanged and in order.
+  assert.deepEqual(
+    after.map((part) => part.id),
+    before.map((part) => part.id),
+    "part ids must survive the round trip",
+  );
+  assert.deepEqual(
+    after.map((part) => part.prompt),
+    before.map((part) => part.prompt),
+  );
+  assert.deepEqual(
+    after.map((part) => part.status),
+    before.map((part) => part.status),
+    "legacy status must not be silently promoted to public",
+  );
+  assert.deepEqual(
+    after.map((part) => part.answerType),
+    before.map((part) => part.answerType),
+  );
+  assert.deepEqual(
+    after.flatMap((part) => (part.criteria ?? []).map((c) => c.points)),
+    before.flatMap((part) => (part.criteria ?? []).map((c) => c.points)),
+  );
+});
+
+test("round trip: exam-wide directions and files are not lost", () => {
+  const loaded = normalizeFrqTemplate(legacyDocument, identity);
+  const reloaded = normalizeFrqTemplate(simulateEditorSave(loaded), identity);
+
+  assert.equal(reloaded.directions, legacyDocument.directions);
+  assert.deepEqual(
+    reloaded.directionsFiles?.map((file) => file.key),
+    ["graph.png"],
+  );
+  assert.equal(reloaded.timeLimitMinutes, 45);
+  assert.equal(reloaded.isPublic, true);
+});
+
+test("round trip is idempotent: saving twice changes nothing", () => {
+  const once = normalizeFrqTemplate(legacyDocument, identity);
+  const twice = normalizeFrqTemplate(simulateEditorSave(once), identity);
+  const thrice = normalizeFrqTemplate(simulateEditorSave(twice), identity);
+
+  assert.deepEqual(getAllParts(thrice), getAllParts(twice));
+  assert.equal(twice.questions.length, 1);
+  assert.equal(thrice.questions.length, 1);
+});
+
+test("a saved document is read back as nested, not re-wrapped as legacy", () => {
+  const loaded = normalizeFrqTemplate(legacyDocument, identity);
+  const saved = simulateEditorSave(loaded);
+  const reloaded = normalizeFrqTemplate(saved, identity);
+
+  // If the save were read as the legacy shape again, the single question would
+  // be treated as one flat part and its 3 parts would collapse to nothing.
+  assert.equal(reloaded.questions.length, 1);
+  assert.equal(reloaded.questions[0]?.id, LEGACY_QUESTION_ID);
+  assert.equal(reloaded.questions[0]?.parts.length, 3);
+});

--- a/scripts/frq-template.test.ts
+++ b/scripts/frq-template.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  LEGACY_QUESTION_ID,
   getAllParts,
   getPartLabel,
   getStudentFacingParts,
@@ -93,7 +94,11 @@ test("the legacy wrap id is stable across reads", () => {
 
   assert.equal(
     normalizeFrqTemplate(raw, identity).questions[0]?.id,
+    LEGACY_QUESTION_ID,
+  );
+  assert.equal(
     normalizeFrqTemplate(raw, identity).questions[0]?.id,
+    LEGACY_QUESTION_ID,
   );
 });
 
@@ -253,6 +258,23 @@ test("a null parts field does not reclassify the whole document", () => {
   assert.deepEqual(out.questions[0]?.parts, []);
   assert.deepEqual(
     out.questions[1]?.parts.map((part) => part.id),
+    ["p1"],
+  );
+});
+
+test("a legacy document with a stray non-object entry keeps its parts", () => {
+  const out = normalizeFrqTemplate(
+    {
+      directions: "Old stimulus",
+      questions: [null, { id: "p1", prompt: "kept" }, "junk"],
+    },
+    { id: "t1", subject: "calc", unitId: "u1" },
+  );
+
+  assert.equal(out.questions.length, 1);
+  assert.equal(out.questions[0]?.id, LEGACY_QUESTION_ID);
+  assert.deepEqual(
+    out.questions[0]?.parts.map((part) => part.id),
     ["p1"],
   );
 });

--- a/scripts/frq-template.test.ts
+++ b/scripts/frq-template.test.ts
@@ -1,8 +1,13 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  getAllParts,
   getPartLabel,
+  getStudentFacingParts,
+  getStudentFacingQuestions,
+  getTemplatePoints,
   hasResponseText,
+  makeId,
   normalizeFrqTemplate,
 } from "../src/lib/frq/template.ts";
 
@@ -49,10 +54,205 @@ test("criteria points are clamped to whole non-negative numbers", () => {
     { id: "t1", subject: "calc", unitId: "u1" },
   );
 
-  const criteria = out.questions[0]?.criteria ?? [];
+  const criteria = out.questions[0]?.parts[0]?.criteria ?? [];
 
   assert.deepEqual(
     criteria.map((criterion) => criterion.points),
     [1, 0, 0],
+  );
+});
+
+test("a legacy flat document is wrapped into one question", () => {
+  const out = normalizeFrqTemplate(
+    {
+      title: "Legacy FRQ",
+      directions: "Old stimulus",
+      questions: [
+        { id: "p1", prompt: "Part one" },
+        { id: "p2", prompt: "Part two" },
+      ],
+    },
+    { id: "t1", subject: "calc", unitId: "u1" },
+  );
+
+  assert.equal(out.questions.length, 1);
+  assert.equal(out.questions[0]?.id, "legacy-question");
+  assert.equal(out.questions[0]?.stimulus, "");
+  assert.deepEqual(
+    out.questions[0]?.parts.map((part) => part.id),
+    ["p1", "p2"],
+  );
+  // Exam-wide directions are untouched, which is what makes the legacy render
+  // byte-identical to today.
+  assert.equal(out.directions, "Old stimulus");
+});
+
+test("the legacy wrap id is stable across reads", () => {
+  const raw = { questions: [{ id: "p1", prompt: "Part one" }] };
+  const identity = { id: "t1", subject: "calc", unitId: "u1" };
+
+  assert.equal(
+    normalizeFrqTemplate(raw, identity).questions[0]?.id,
+    normalizeFrqTemplate(raw, identity).questions[0]?.id,
+  );
+});
+
+test("a nested document is read as authored", () => {
+  const out = normalizeFrqTemplate(
+    {
+      title: "Nested FRQ",
+      sectionLabel: "Section I, Part B",
+      sectionSubtitle: "Short answer",
+      questions: [
+        {
+          id: "q1",
+          stimulus: "Graph A",
+          parts: [{ id: "p1", prompt: "Part one" }],
+        },
+        { id: "q2", stimulus: "Table B", parts: [] },
+      ],
+    },
+    { id: "t1", subject: "calc", unitId: "u1" },
+  );
+
+  assert.equal(out.questions.length, 2);
+  assert.equal(out.questions[0]?.stimulus, "Graph A");
+  assert.deepEqual(
+    out.questions[0]?.parts.map((part) => part.id),
+    ["p1"],
+  );
+  // An empty parts array is still the new shape, not a legacy document.
+  assert.deepEqual(out.questions[1]?.parts, []);
+  assert.equal(out.sectionLabel, "Section I, Part B");
+  assert.equal(out.sectionSubtitle, "Short answer");
+});
+
+test("parts with no stable id are dropped in both shapes", () => {
+  const identity = { id: "t1", subject: "calc", unitId: "u1" };
+
+  const legacy = normalizeFrqTemplate(
+    { questions: [{ id: "p1" }, { prompt: "no id" }] },
+    identity,
+  );
+
+  const nested = normalizeFrqTemplate(
+    { questions: [{ id: "q1", parts: [{ id: "p1" }, { prompt: "no id" }] }] },
+    identity,
+  );
+
+  assert.deepEqual(
+    legacy.questions[0]?.parts.map((part) => part.id),
+    ["p1"],
+  );
+  assert.deepEqual(
+    nested.questions[0]?.parts.map((part) => part.id),
+    ["p1"],
+  );
+});
+
+const twoQuestionTemplate = () =>
+  normalizeFrqTemplate(
+    {
+      questions: [
+        {
+          id: "q1",
+          parts: [
+            {
+              id: "p1",
+              criteria: [{ id: "c1", description: "x", points: 2 }],
+            },
+            { id: "p2", status: "legacy" },
+          ],
+        },
+        {
+          id: "q2",
+          parts: [
+            {
+              id: "p3",
+              criteria: [{ id: "c2", description: "y", points: 3 }],
+            },
+          ],
+        },
+        { id: "q3", parts: [{ id: "p4", status: "legacy" }] },
+      ],
+    },
+    { id: "t1", subject: "calc", unitId: "u1" },
+  );
+
+test("getAllParts flattens in reading order and keeps legacy parts", () => {
+  assert.deepEqual(
+    getAllParts(twoQuestionTemplate()).map((part) => part.id),
+    ["p1", "p2", "p3", "p4"],
+  );
+});
+
+test("getStudentFacingParts drops legacy parts", () => {
+  assert.deepEqual(
+    getStudentFacingParts(twoQuestionTemplate()).map((part) => part.id),
+    ["p1", "p3"],
+  );
+});
+
+test("getStudentFacingQuestions drops questions with no visible parts", () => {
+  const questions = getStudentFacingQuestions(twoQuestionTemplate());
+
+  assert.deepEqual(
+    questions.map((question) => question.id),
+    ["q1", "q2"],
+  );
+  assert.deepEqual(
+    questions[0]?.parts.map((part) => part.id),
+    ["p1"],
+  );
+});
+
+test("getTemplatePoints sums across questions", () => {
+  assert.equal(getTemplatePoints(getAllParts(twoQuestionTemplate())), 5);
+});
+
+test("makeId is prefixed and collision-safe within a millisecond", () => {
+  const ids = new Set(Array.from({ length: 500 }, () => makeId("part")));
+
+  assert.equal(ids.size, 500);
+  assert.ok([...ids].every((id) => id.startsWith("part-")));
+});
+
+test("one malformed entry does not discard other questions' parts", () => {
+  const out = normalizeFrqTemplate(
+    {
+      questions: [
+        { id: "q1", parts: [{ id: "p1", prompt: "kept" }] },
+        { id: "stray", prompt: "no parts array" },
+      ],
+    },
+    { id: "t1", subject: "calc", unitId: "u1" },
+  );
+
+  assert.deepEqual(
+    out.questions.map((question) => question.id),
+    ["q1", "stray"],
+  );
+  assert.deepEqual(
+    out.questions[0]?.parts.map((part) => part.id),
+    ["p1"],
+  );
+  assert.deepEqual(out.questions[1]?.parts, []);
+});
+
+test("a null parts field does not reclassify the whole document", () => {
+  const out = normalizeFrqTemplate(
+    {
+      questions: [
+        { id: "q1", parts: null },
+        { id: "q2", parts: [{ id: "p1", prompt: "kept" }] },
+      ],
+    },
+    { id: "t1", subject: "calc", unitId: "u1" },
+  );
+
+  assert.deepEqual(out.questions[0]?.parts, []);
+  assert.deepEqual(
+    out.questions[1]?.parts.map((part) => part.id),
+    ["p1"],
   );
 });

--- a/scripts/frq-template.test.ts
+++ b/scripts/frq-template.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  getPartLabel,
+  hasResponseText,
+  normalizeFrqTemplate,
+} from "../src/lib/frq/template.ts";
+
+test("part labels do not walk off the alphabet", () => {
+  assert.equal(getPartLabel(0), "A");
+  assert.equal(getPartLabel(25), "Z");
+  assert.equal(getPartLabel(26), "AA");
+});
+
+test("hasResponseText ignores markup-only responses", () => {
+  assert.equal(hasResponseText("<p></p>"), false);
+  assert.equal(hasResponseText("<p>&nbsp;</p>"), false);
+  assert.equal(hasResponseText("<p>an answer</p>"), true);
+  assert.equal(hasResponseText(undefined), false);
+});
+
+test("a malformed document degrades instead of throwing", () => {
+  const out = normalizeFrqTemplate(null, {
+    id: "t1",
+    subject: "calc",
+    unitId: "u1",
+  });
+
+  assert.equal(out.title, "Untitled FRQ");
+  assert.equal(out.subject, "calc");
+  assert.deepEqual(out.questions, []);
+  assert.equal(out.timeLimitMinutes, 90);
+});
+
+test("criteria points are clamped to whole non-negative numbers", () => {
+  const out = normalizeFrqTemplate(
+    {
+      questions: [
+        {
+          id: "p1",
+          criteria: [
+            { id: "c1", description: "half", points: 1.4 },
+            { id: "c2", description: "negative", points: -3 },
+            { id: "c3", description: "junk", points: "abc" },
+          ],
+        },
+      ],
+    },
+    { id: "t1", subject: "calc", unitId: "u1" },
+  );
+
+  const criteria = out.questions[0]?.criteria ?? [];
+
+  assert.deepEqual(
+    criteria.map((criterion) => criterion.points),
+    [1, 0, 0],
+  );
+});

--- a/src/components/frq/editorRenderer.tsx
+++ b/src/components/frq/editorRenderer.tsx
@@ -26,8 +26,11 @@ import { Textarea } from "@/components/ui/textarea";
 import { getFrqTemplateDocRef } from "@/lib/firestore/frqRefs";
 import {
   DEFAULT_TIME_LIMIT_MINUTES,
+  getAllParts,
   getPartLabel,
-  getQuestionPoints,
+  getPartPoints,
+  LEGACY_QUESTION_ID,
+  makeId,
   toQuestionInput,
 } from "@/lib/frq/template";
 import type { QuestionFormat, QuestionInput } from "@/types/questions";
@@ -38,7 +41,7 @@ import type {
   FRQGradingCriterion,
   FRQQuestionStatus,
   FRQTemplate,
-  FRQTemplateQuestion,
+  FRQTemplatePart,
 } from "@/types/frq";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -61,16 +64,6 @@ const createQuestionInput = (value = ""): QuestionInput => ({
   value,
   files: [],
 });
-
-/**
- * Unique, immutable ID built from the current time plus a short random suffix.
- * The random half is what makes it collision-safe: a timestamp alone repeats
- * when several IDs are minted in the same millisecond.
- */
-const makeId = (prefix: string) =>
-  `${prefix}-${Date.now().toString(36)}-${Math.random()
-    .toString(36)
-    .slice(2, 8)}`;
 
 const formatPoints = (points: number) =>
   `${points} ${points === 1 ? "point" : "points"}`;
@@ -96,7 +89,7 @@ const createEditorQuestion = (): EditorQuestion => ({
 });
 
 const createEditorQuestionFromTemplate = (
-  templateQuestion: FRQTemplateQuestion,
+  templateQuestion: FRQTemplatePart,
 ): EditorQuestion => ({
   id: templateQuestion.id,
   questionData: createQuestionData(
@@ -117,11 +110,10 @@ interface EditorState {
 
 const buildInitialState = (template: FRQTemplate | null): EditorState => ({
   title: template?.title ?? "",
-  description: toQuestionInput(
-    template?.directions,
-    template?.directionsFiles,
+  description: toQuestionInput(template?.directions, template?.directionsFiles),
+  questions: (template ? getAllParts(template) : []).map(
+    createEditorQuestionFromTemplate,
   ),
-  questions: (template?.questions ?? []).map(createEditorQuestionFromTemplate),
   timeLimitMinutes: template?.timeLimitMinutes ?? DEFAULT_TIME_LIMIT_MINUTES,
   isPublic: template?.isPublic === true,
 });
@@ -139,15 +131,24 @@ const buildTemplatePayload = (state: EditorState) => ({
   directionsFiles: state.description.files,
   timeLimitMinutes: state.timeLimitMinutes,
   isPublic: state.isPublic,
-  questions: state.questions.map((question, index) => ({
-    id: question.id,
-    title: getPartLabel(index),
-    prompt: question.questionData.question.value,
-    promptFiles: question.questionData.question.files,
-    answerType: question.answerType,
-    status: question.status,
-    criteria: question.criteria,
-  })),
+  // PR 1 authors a single question; PR 2 adds the question-level UI. Wrapping
+  // here means a save from the current editor already writes the new shape.
+  questions: [
+    {
+      id: LEGACY_QUESTION_ID,
+      stimulus: "",
+      stimulusFiles: [],
+      parts: state.questions.map((question, index) => ({
+        id: question.id,
+        title: getPartLabel(index),
+        prompt: question.questionData.question.value,
+        promptFiles: question.questionData.question.files,
+        answerType: question.answerType,
+        status: question.status,
+        criteria: question.criteria,
+      })),
+    },
+  ],
 });
 
 const FRQEditorRenderer = ({
@@ -316,7 +317,7 @@ const FRQEditorRenderer = ({
   const totalPoints = questions.reduce(
     (total, question) =>
       total +
-      getQuestionPoints({
+      getPartPoints({
         id: question.id,
         title: "",
         criteria: question.criteria,
@@ -373,11 +374,7 @@ const FRQEditorRenderer = ({
             type="button"
             onClick={() => void saveTemplate()}
             disabled={saveState === "saving" || !hasUnsavedChanges}
-            title={
-              hasUnsavedChanges
-                ? "Save this FRQ"
-                : "No changes to save"
-            }
+            title={hasUnsavedChanges ? "Save this FRQ" : "No changes to save"}
           >
             <Save className="mr-2 size-4" />
             {saveState === "saving" ? "Saving..." : "Save Changes"}
@@ -492,7 +489,7 @@ const FRQEditorRenderer = ({
                       </span>
                       <span className="text-sm font-normal text-muted-foreground">
                         {formatPoints(
-                          getQuestionPoints({
+                          getPartPoints({
                             id: question.id,
                             title: "",
                             criteria: question.criteria,

--- a/src/components/frq/gradingRenderer.tsx
+++ b/src/components/frq/gradingRenderer.tsx
@@ -16,8 +16,9 @@ import {
   getUngradedFrqDocRef,
 } from "@/lib/firestore/frqRefs";
 import {
+  getAllParts,
   getPartLabel,
-  getQuestionPoints,
+  getPartPoints,
   getTemplatePoints,
   toQuestionInput,
 } from "@/lib/frq/template";
@@ -25,7 +26,7 @@ import {
 import { useUser } from "@/components/hooks/UserContext";
 import type {
   FRQTemplate,
-  FRQTemplateQuestion,
+  FRQTemplatePart,
   GradableFRQSubmission,
 } from "@/types/frq";
 
@@ -40,7 +41,7 @@ type PartGrade = {
   criteria: Record<string, number>;
 };
 
-const createEmptyGrade = (question: FRQTemplateQuestion): PartGrade => ({
+const createEmptyGrade = (question: FRQTemplatePart): PartGrade => ({
   feedback: "",
   criteria: Object.fromEntries(
     (question.criteria ?? []).map((criterion) => [criterion.id, 0]),
@@ -55,7 +56,10 @@ const FRQGradingRenderer = ({
 
   // Grading covers every part the template defines, including ones marked
   // legacy: an older submission may still hold a response to them.
-  const questions = useMemo(() => template?.questions ?? [], [template]);
+  const questions = useMemo(
+    () => (template ? getAllParts(template) : []),
+    [template],
+  );
 
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isNavigationOpen, setIsNavigationOpen] = useState(false);
@@ -275,7 +279,7 @@ const FRQGradingRenderer = ({
               {getPartLabel(currentIndex)}
             </span>
             <span className="px-3 font-semibold tabular-nums">
-              {currentEarned}/{getQuestionPoints(currentQuestion)} Points
+              {currentEarned}/{getPartPoints(currentQuestion)} Points
             </span>
           </div>
 

--- a/src/components/frq/testRenderer.tsx
+++ b/src/components/frq/testRenderer.tsx
@@ -8,7 +8,7 @@ import { getUngradedFrqsCollectionRef } from "@/lib/firestore/frqRefs";
 import {
   DEFAULT_TIME_LIMIT_MINUTES,
   getPartLabel,
-  getStudentFacingQuestions,
+  getStudentFacingParts,
   hasResponseText,
   toQuestionInput,
 } from "@/lib/frq/template";
@@ -42,7 +42,11 @@ const readDraft = (draftKey: string): Record<string, string> => {
 
     const parsed: unknown = JSON.parse(stored);
 
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
       return {};
     }
 
@@ -65,8 +69,10 @@ const FRQTestRenderer = ({
   const router = useRouter();
   const { user } = useUser();
 
+  // PR 1 keeps the flat part list so behaviour is unchanged. PR 3 replaces this
+  // with per-question paging.
   const questions = useMemo(
-    () => (template ? getStudentFacingQuestions(template) : []),
+    () => (template ? getStudentFacingParts(template) : []),
     [template],
   );
 

--- a/src/lib/frq/feedbackDocument.ts
+++ b/src/lib/frq/feedbackDocument.ts
@@ -1,7 +1,7 @@
 import type { FRQFeedbackDocument } from "@/components/frq/feedback/types";
 import type { FRQTemplate, GradedFRQSubmission } from "@/types/frq";
 import type { Timestamp } from "firebase/firestore";
-import { toQuestionInput } from "./template";
+import { getAllParts, toQuestionInput } from "./template";
 
 const formatTimestamp = (value: Timestamp | undefined) => {
   if (!value || typeof value.toDate !== "function") {
@@ -39,17 +39,17 @@ export const buildFeedbackDocument = (
       id: graded.sourceSubmissionId,
       graderId: graded.graderId,
       submittedAt: formatTimestamp(graded.gradedAt),
-      questions: template.questions.map((question) => {
+      questions: getAllParts(template).map((part) => {
         const partGrade = grades.find(
-          (grade) => grade.questionId === question.id,
+          (grade) => grade.questionId === part.id,
         );
 
         return {
-          questionId: question.id,
+          questionId: part.id,
           feedback: partGrade?.feedback ?? "",
           // Every criterion gets a row even when the grader left it at zero, so
           // the student sees the whole rubric rather than only what was earned.
-          gradingCriteria: (question.criteria ?? []).map((criterion) => ({
+          gradingCriteria: (part.criteria ?? []).map((criterion) => ({
             criterionId: criterion.id,
             points:
               partGrade?.criteria.find(
@@ -64,9 +64,9 @@ export const buildFeedbackDocument = (
       id: graded.sourceSubmissionId,
       userId: graded.studentId,
       submittedAt: formatTimestamp(graded.submittedAt),
-      answers: template.questions.map((question) => ({
-        questionId: question.id,
-        value: graded.responses?.[question.id] ?? "",
+      answers: getAllParts(template).map((part) => ({
+        questionId: part.id,
+        value: graded.responses?.[part.id] ?? "",
       })),
     },
 
@@ -79,13 +79,13 @@ export const buildFeedbackDocument = (
           template.directionsFiles,
         ),
         isVisible: true,
-        questions: template.questions.map((question) => ({
-          id: question.id,
-          name: question.title,
-          isVisible: question.status !== "legacy",
-          prompt: toQuestionInput(question.prompt, question.promptFiles),
+        questions: getAllParts(template).map((part) => ({
+          id: part.id,
+          name: part.title,
+          isVisible: part.status !== "legacy",
+          prompt: toQuestionInput(part.prompt, part.promptFiles),
           answerType: "text" as const,
-          gradingCriteria: (question.criteria ?? []).map((criterion) => ({
+          gradingCriteria: (part.criteria ?? []).map((criterion) => ({
             id: criterion.id,
             text: criterion.description,
             points: criterion.points,

--- a/src/lib/frq/template.ts
+++ b/src/lib/frq/template.ts
@@ -84,7 +84,8 @@ const normalizeStatus = (value: unknown): FRQQuestionStatus =>
   value === "legacy" ? "legacy" : "public";
 
 /**
- * The id of the single question that legacy flat documents are wrapped into.
+ * The id of the single question that legacy flat documents are wrapped into,
+ * and also minted for every new save (including brand-new FRQs never legacy).
  * A constant rather than a generated id: the wrap is re-derived on every read,
  * so a random id would differ between two reads of the same document.
  */
@@ -158,16 +159,13 @@ const normalizeQuestions = (value: unknown): FRQTemplateQuestion[] => {
     return [];
   }
 
-  // A document is legacy only if EVERY entry lacks a parts array. Using `some`
-  // here let one malformed entry reclassify the whole document and silently
-  // discard the nested parts of every other question.
+  // Legacy iff NO entry carries a parts array. Stated negatively on purpose:
+  // an `every` over "lacks parts" also fails on non-object entries, which
+  // misclassified a legacy document containing a stray null as nested and
+  // silently discarded all of its parts.
   const isLegacyShape =
     value.length > 0 &&
-    value.every((entry) => {
-      const record = asRecord(entry);
-
-      return record !== null && !Array.isArray(record.parts);
-    });
+    !value.some((entry) => Array.isArray(asRecord(entry)?.parts));
 
   if (!isLegacyShape) {
     return value.flatMap(normalizeQuestion);

--- a/src/lib/frq/template.ts
+++ b/src/lib/frq/template.ts
@@ -3,6 +3,7 @@ import type {
   FRQGradingCriterion,
   FRQQuestionStatus,
   FRQTemplate,
+  FRQTemplatePart,
   FRQTemplateQuestion,
 } from "@/types/frq";
 import type { QuestionFile, QuestionInput } from "@/types/questions";
@@ -82,10 +83,14 @@ const normalizeAnswerType = (value: unknown): FRQAnswerType =>
 const normalizeStatus = (value: unknown): FRQQuestionStatus =>
   value === "legacy" ? "legacy" : "public";
 
-const normalizeQuestion = (
-  value: unknown,
-  index: number,
-): FRQTemplateQuestion[] => {
+/**
+ * The id of the single question that legacy flat documents are wrapped into.
+ * A constant rather than a generated id: the wrap is re-derived on every read,
+ * so a random id would differ between two reads of the same document.
+ */
+export const LEGACY_QUESTION_ID = "legacy-question";
+
+const normalizePart = (value: unknown, index: number): FRQTemplatePart[] => {
   const record = asRecord(value);
 
   if (!record) {
@@ -114,6 +119,74 @@ const normalizeQuestion = (
   ];
 };
 
+const normalizeQuestion = (value: unknown): FRQTemplateQuestion[] => {
+  const record = asRecord(value);
+
+  if (!record) {
+    return [];
+  }
+
+  const id = asString(record.id);
+
+  if (!id) {
+    return [];
+  }
+
+  return [
+    {
+      id,
+      stimulus: asString(record.stimulus),
+      stimulusFiles: normalizeFiles(record.stimulusFiles),
+      parts: Array.isArray(record.parts)
+        ? record.parts.flatMap(normalizePart)
+        : [],
+    },
+  ];
+};
+
+/**
+ * Documents written before the question/part split stored a flat list of parts
+ * under `questions`. They are detected by the absence of a `parts` array — a
+ * question authored under the new shape always has one, even when empty — and
+ * wrapped into a single question so the rest of the app sees one shape.
+ *
+ * The template's `directions` was already the stimulus those documents used,
+ * and it stays exam-wide, so a wrapped document renders exactly as before.
+ */
+const normalizeQuestions = (value: unknown): FRQTemplateQuestion[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  // A document is legacy only if EVERY entry lacks a parts array. Using `some`
+  // here let one malformed entry reclassify the whole document and silently
+  // discard the nested parts of every other question.
+  const isLegacyShape =
+    value.length > 0 &&
+    value.every((entry) => {
+      const record = asRecord(entry);
+
+      return record !== null && !Array.isArray(record.parts);
+    });
+
+  if (!isLegacyShape) {
+    return value.flatMap(normalizeQuestion);
+  }
+
+  const parts = value.flatMap(normalizePart);
+
+  return parts.length > 0
+    ? [
+        {
+          id: LEGACY_QUESTION_ID,
+          stimulus: "",
+          stimulusFiles: [],
+          parts,
+        },
+      ]
+    : [];
+};
+
 /**
  * Turn a raw Firestore FRQ document into a template every page can trust.
  * `identity` supplies the values that live in the document path rather than the
@@ -134,9 +207,9 @@ export const normalizeFrqTemplate = (
     title: asString(record.title) || "Untitled FRQ",
     directions: asString(record.directions),
     directionsFiles: normalizeFiles(record.directionsFiles),
-    questions: Array.isArray(record.questions)
-      ? record.questions.flatMap(normalizeQuestion)
-      : [],
+    sectionLabel: asString(record.sectionLabel),
+    sectionSubtitle: asString(record.sectionSubtitle),
+    questions: normalizeQuestions(record.questions),
     isPublic: record.isPublic === true,
     timeLimitMinutes:
       Number.isFinite(timeLimit) && timeLimit >= 1
@@ -153,21 +226,39 @@ export const toQuestionInput = (
   files: files ? [...files] : [],
 });
 
-/** Parts a student actually sits. Legacy parts stay readable but unassigned. */
-export const getStudentFacingQuestions = (template: FRQTemplate) =>
-  template.questions.filter((question) => question.status !== "legacy");
+/** Every part in the document, in reading order, ignoring visibility. */
+export const getAllParts = (template: FRQTemplate): FRQTemplatePart[] =>
+  template.questions.flatMap((question) => question.parts);
 
-export const getQuestionPoints = (question: FRQTemplateQuestion) =>
-  (question.criteria ?? []).reduce(
+/** Parts a student actually sits. Legacy parts stay readable but unassigned. */
+export const getStudentFacingParts = (
+  template: FRQTemplate,
+): FRQTemplatePart[] =>
+  getAllParts(template).filter((part) => part.status !== "legacy");
+
+/**
+ * Questions a student actually sits, each carrying only its visible parts.
+ * A question whose parts are all legacy is dropped, so the test never pages to
+ * a question with nothing on it.
+ */
+export const getStudentFacingQuestions = (
+  template: FRQTemplate,
+): FRQTemplateQuestion[] =>
+  template.questions
+    .map((question) => ({
+      ...question,
+      parts: question.parts.filter((part) => part.status !== "legacy"),
+    }))
+    .filter((question) => question.parts.length > 0);
+
+export const getPartPoints = (part: FRQTemplatePart) =>
+  (part.criteria ?? []).reduce(
     (total, criterion) => total + criterion.points,
     0,
   );
 
-export const getTemplatePoints = (questions: FRQTemplateQuestion[]) =>
-  questions.reduce(
-    (total, question) => total + getQuestionPoints(question),
-    0,
-  );
+export const getTemplatePoints = (parts: FRQTemplatePart[]) =>
+  parts.reduce((total, part) => total + getPartPoints(part), 0);
 
 /**
  * AP-style part label: A, B, C ... then AA, AB past 26 parts rather than
@@ -191,3 +282,13 @@ export const hasResponseText = (response: string | undefined) =>
     .replace(/<[^>]*>/g, "")
     .replace(/&nbsp;/g, " ")
     .trim().length > 0;
+
+/**
+ * Unique, immutable ID built from the current time plus a short random suffix.
+ * The random half is what makes it collision-safe: a timestamp alone repeats
+ * when several IDs are minted in the same millisecond.
+ */
+export const makeId = (prefix: string) =>
+  `${prefix}-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 8)}`;

--- a/src/types/frq.ts
+++ b/src/types/frq.ts
@@ -22,7 +22,8 @@ export interface FRQGradingCriterion {
   points: number;
 }
 
-export interface FRQTemplateQuestion {
+/** One part — the unit a student writes a single response to. */
+export interface FRQTemplatePart {
   /** Stable template-local identifier; never derived from display order. */
   id: string;
   title: string;
@@ -32,6 +33,19 @@ export interface FRQTemplateQuestion {
   answerType?: FRQAnswerType;
   status?: FRQQuestionStatus;
   criteria?: FRQGradingCriterion[];
+}
+
+/**
+ * One numbered question: its own stimulus plus the parts hanging off it.
+ * Part labels restart at A within each question, which is how AP numbers them.
+ */
+export interface FRQTemplateQuestion {
+  /** Stable template-local identifier; never derived from display order. */
+  id: string;
+  /** Stimulus shown in the left pane while this question is open. */
+  stimulus?: string;
+  stimulusFiles?: QuestionFile[];
+  parts: FRQTemplatePart[];
 }
 
 /** An admin-authored prompt used by the digital FRQ testing experience. */
@@ -47,6 +61,13 @@ export interface FRQTemplate {
    */
   directions: string;
   directionsFiles?: QuestionFile[];
+  /**
+   * Section heading shown while taking the test, e.g. "Section II" or
+   * "Section I, Part B". Absent on templates authored before this was
+   * configurable, which fall back to the original hardcoded strings.
+   */
+  sectionLabel?: string;
+  sectionSubtitle?: string;
   questions: FRQTemplateQuestion[];
   isPublic?: boolean;
   /** Minutes on the test clock. Absent on templates authored before timing. */
@@ -79,6 +100,11 @@ export interface FRQCriterionScore {
  * were earned and what the grader said about each part.
  */
 export interface FRQQuestionGrade {
+  /**
+   * The id of the FRQTemplatePart this grade covers. Named `questionId`
+   * because it is a stored field in `graded-frqs` that predates the
+   * question/part split — renaming it would orphan existing documents.
+   */
   questionId: string;
   feedback: string;
   criteria: FRQCriterionScore[];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     /* Bundled projects */
     "lib": ["dom", "dom.iterable", "ES2022"],
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "jsx": "preserve",


### PR DESCRIPTION
## Goal

Testers reported three problems: you cannot put multiple FRQs in one exam, each FRQ has to be authored as a separate navigable "part", and the "Section II / Free response" heading never changes.

One cause sits under all three. `FRQTemplate` holds a single `directions` field and a flat `questions[]`, so nothing exists between "exam" and "part". A second question has nowhere to live except the parts list.

This PR adds the missing level. Students and authors see no change yet. PRs 2 through 4 build the interface on top of it.

## What changes here

`FRQTemplatePart` takes over the old part shape. `FRQTemplateQuestion` becomes the outer level and owns `stimulus`, `stimulusFiles` and `parts`. That matches the vocabulary `src/components/frq/feedback/types.ts` already uses, so both halves of the codebase now agree on what "question" means.

`FRQTemplate` gains `sectionLabel` and `sectionSubtitle`. Nothing reads them until PR 3.

`normalizeFrqTemplate` recognises the old flat shape and wraps it into one question with the constant id `legacy-question`.

The four consumers (`testRenderer`, `gradingRenderer`, `editorRenderer`, `feedbackDocument`) now call `getAllParts` or `getStudentFacingParts`. Each receives the same list it received before, which is what holds behaviour steady.

`buildTemplatePayload` writes the nested shape, so saving from the current editor no longer downgrades a document.

## Migration

None. `responses` stays keyed by part id, and part ids were already unique across a document, so existing submissions, grades and feedback keep resolving. Template-level `directions` stays exam-wide, so a document written before this change renders the way it did yesterday. No backfill script, no downtime.

`FRQQuestionGrade.questionId` keeps its name. It is a stored field in `graded-frqs` and now means "part id". Renaming it would orphan every graded document.

## Sequencing constraint

`buildTemplatePayload` writes exactly one question. Once PR 3 lets authors build multi-question exams, opening one of those in this PR's editor and saving collapses it back to a single question and drops every stimulus and question boundary. Part ids survive; the structure does not. Nothing writes a multi-question document yet, so no one can hit this today.

**PR 1 and PR 3 must not ship without PR 2.**

## Testing

The repo had no test runner. This adds one without a new dependency: Node 22's built-in `node:test` with native type stripping. `npm test` runs 20 tests.

The suite covers both directions of the legacy-shape check, and both directions destroyed data at some point on this branch. A mixed array discarded nested parts. The fix for that then discarded a whole document's parts when the document contained a stray `null`. Each case now has a regression test that fails against the old code.

Four round-trip tests load a legacy document, save it, and load it again, asserting that part ids, prompts, `legacy` status, answer types and criterion values all survive.

`npm test` 20/20, `npx tsc --noEmit` clean, `npm run lint` clean, `npm run build` succeeds.

I did not use the Firebase emulator. `src/lib/firebase.ts` carries no emulator wiring and the repo ships no seed data, so I covered the risk at the data layer and smoke-tested the dev server against `/`, the student FRQ route and `/frq-grading`.

## What PRs 2 through 4 cover

**PR 2, authoring.** The admin editor gains the second level. "Add Question" creates a card holding its own stimulus editor and a nested list of parts, and the left pane gains the section label fields. Watch `AdvancedTextbox` in review: it hands back its whole array on every change, and the current code already works around a slow upload overwriting a sibling part. Nesting recreates that hazard one level up.

**PR 3, taking the test.** Students page between questions rather than parts, and a question's parts stack on one page. The left pane shows that question's own stimulus. The header reads the authored section label, so an exam with SAQs can say "Section I, Part B". Testers see all three of their complaints answered here.

**PR 4, grading and feedback.** Graders page by question with that question's parts and rubrics beside them, matching the student feedback page. `buildFeedbackDocument` stops hardcoding a single-entry array. The feedback UI needs no changes, because it already models questions containing parts.
