### PR TITLE
FRQ PR 2: author questions containing parts

### DIFF
--- a/scripts/frq-editor-state.test.ts
+++ b/scripts/frq-editor-state.test.ts
@@ -4,7 +4,9 @@ import {
   buildInitialState,
   buildTemplatePayload,
   canMovePart,
+  deletePartById,
   movePart,
+  updatePartById,
 } from "../src/lib/frq/editorState.ts";
 import { normalizeFrqTemplate } from "../src/lib/frq/template.ts";
 
@@ -91,22 +93,70 @@ test("part labels restart at A inside every question", () => {
   );
 });
 
-test("a section heading round trips, and a blank one is not stored", () => {
+test("a section heading round trips; a blank one normalizes back to absent", () => {
   const configured = buildTemplatePayload(openEditor(nestedDocument));
 
   assert.equal(configured.sectionLabel, "Section I, Part B");
   assert.equal(configured.sectionSubtitle, "Short answer");
 
-  // An untouched heading saves as "", which the editor writes as a field
-  // delete so the reloaded template falls back rather than showing a blank.
+  // An untouched heading reaches the payload as "".
   const untouched = buildTemplatePayload(openEditor({ title: "No heading" }));
 
   assert.equal(untouched.sectionLabel, "");
-  assert.equal(
-    normalizeFrqTemplate({ ...untouched, sectionLabel: undefined }, identity)
-      .sectionLabel,
-    undefined,
+  assert.equal(untouched.sectionSubtitle, "");
+
+  // Were a "" ever to reach the document, reading it back still yields an
+  // absent key, so a `?? "Section II"` fallback holds either way. The editor
+  // additionally maps "" to deleteField() so the key never gets stored at all;
+  // that mapping lives in editorRenderer and is NOT covered here, because
+  // importing firebase/firestore would need a bundler this runner does not have.
+  const stored = normalizeFrqTemplate(untouched, identity);
+
+  assert.equal("sectionLabel" in stored, false);
+  assert.equal(stored.sectionLabel ?? "Section II", "Section II");
+});
+
+test("a part edit finds the part after it moved to another question", () => {
+  const { questions } = openEditor(nestedDocument);
+
+  // The M1 scenario: an upload starts against part-a in question 1, the author
+  // moves part-a into question 2, and only then does the upload resolve.
+  const moved = movePart(questions, "part-a", 1);
+  const edited = updatePartById(moved, "part-a", (part) => ({
+    ...part,
+    criteria: [{ id: "c9", description: "Uploaded", points: 5 }],
+  }));
+
+  const landed = edited
+    .flatMap((question) => question.parts)
+    .find((part) => part.id === "part-a");
+
+  assert.deepEqual(
+    landed?.criteria.map((criterion) => criterion.points),
+    [5],
+    "an edit addressed by part id must land wherever the part now lives",
   );
+
+  // Questions holding no matching part keep their identity, so one part's
+  // keystroke does not re-render every other question card.
+  assert.equal(edited[1], moved[1]);
+});
+
+test("deleting a part removes exactly that part, wherever it lives", () => {
+  const { questions } = openEditor(nestedDocument);
+
+  assert.deepEqual(
+    deletePartById(questions, "part-b").map((question) =>
+      question.parts.map((part) => part.id),
+    ),
+    [["part-a"], ["part-c"]],
+  );
+
+  // An id no question holds leaves every question untouched by identity.
+  const missing = deletePartById(questions, "nope");
+
+  assert.equal(missing[0], questions[0]);
+  assert.equal(missing[1], questions[1]);
 });
 
 test("moving a part down past the last one enters the next question", () => {

--- a/scripts/frq-editor-state.test.ts
+++ b/scripts/frq-editor-state.test.ts
@@ -219,10 +219,7 @@ test("an FRQ with no questions still opens with somewhere to add a part", () => 
   assert.deepEqual(state.questions[0]?.parts, []);
 
   // An empty question saves as the nested shape, not as a legacy document.
-  const reloaded = normalizeFrqTemplate(
-    buildTemplatePayload(state),
-    identity,
-  );
+  const reloaded = normalizeFrqTemplate(buildTemplatePayload(state), identity);
 
   assert.equal(reloaded.questions.length, 1);
   assert.deepEqual(reloaded.questions[0]?.parts, []);

--- a/scripts/frq-editor-state.test.ts
+++ b/scripts/frq-editor-state.test.ts
@@ -1,0 +1,229 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  buildInitialState,
+  buildTemplatePayload,
+  canMovePart,
+  movePart,
+} from "../src/lib/frq/editorState.ts";
+import { normalizeFrqTemplate } from "../src/lib/frq/template.ts";
+
+const identity = { id: "t1", subject: "calc", unitId: "u1" };
+
+/** Two questions, each with its own stimulus: what PR 2 lets authors build. */
+const nestedDocument = {
+  title: "Unit 4 FRQ",
+  directions: "<p>Answer both questions.</p>",
+  sectionLabel: "Section I, Part B",
+  sectionSubtitle: "Short answer",
+  timeLimitMinutes: 40,
+  isPublic: true,
+  questions: [
+    {
+      id: "q1",
+      stimulus: "<p>The graph shows velocity over time.</p>",
+      stimulusFiles: [{ key: "graph.png", name: "graph.png" }],
+      parts: [
+        {
+          id: "part-a",
+          title: "A",
+          prompt: "<p>Find the acceleration.</p>",
+          status: "public",
+          criteria: [{ id: "c1", description: "Correct value", points: 2 }],
+        },
+        {
+          id: "part-b",
+          title: "B",
+          prompt: "<p>Justify your answer.</p>",
+          answerType: "equation",
+          status: "public",
+          criteria: [],
+        },
+      ],
+    },
+    {
+      id: "q2",
+      stimulus: "<p>A second source.</p>",
+      parts: [
+        {
+          id: "part-c",
+          title: "A",
+          prompt: "<p>Compare the two.</p>",
+          status: "public",
+          criteria: [{ id: "c2", description: "Names both", points: 1 }],
+        },
+      ],
+    },
+  ],
+};
+
+const openEditor = (raw: unknown) =>
+  buildInitialState(normalizeFrqTemplate(raw, identity));
+
+test("a multi-question document survives load -> save -> reload", () => {
+  const saved = buildTemplatePayload(openEditor(nestedDocument));
+  const reloaded = normalizeFrqTemplate(saved, identity);
+
+  // The property PR 1's editor could not hold: two questions stay two
+  // questions, each keeping its own stimulus and its own parts.
+  assert.equal(reloaded.questions.length, 2);
+  assert.equal(
+    reloaded.questions[0]?.stimulus,
+    "<p>The graph shows velocity over time.</p>",
+  );
+  assert.equal(reloaded.questions[1]?.stimulus, "<p>A second source.</p>");
+  assert.deepEqual(
+    reloaded.questions.map((question) => question.parts.map((part) => part.id)),
+    [["part-a", "part-b"], ["part-c"]],
+  );
+  assert.deepEqual(
+    reloaded.questions[0]?.stimulusFiles?.map((file) => file.key),
+    ["graph.png"],
+  );
+});
+
+test("part labels restart at A inside every question", () => {
+  const saved = buildTemplatePayload(openEditor(nestedDocument));
+
+  assert.deepEqual(
+    saved.questions.map((question) => question.parts.map((part) => part.title)),
+    [["A", "B"], ["A"]],
+  );
+});
+
+test("a section heading round trips, and a blank one is not stored", () => {
+  const configured = buildTemplatePayload(openEditor(nestedDocument));
+
+  assert.equal(configured.sectionLabel, "Section I, Part B");
+  assert.equal(configured.sectionSubtitle, "Short answer");
+
+  // An untouched heading saves as "", which the editor writes as a field
+  // delete so the reloaded template falls back rather than showing a blank.
+  const untouched = buildTemplatePayload(openEditor({ title: "No heading" }));
+
+  assert.equal(untouched.sectionLabel, "");
+  assert.equal(
+    normalizeFrqTemplate({ ...untouched, sectionLabel: undefined }, identity)
+      .sectionLabel,
+    undefined,
+  );
+});
+
+test("moving a part down past the last one enters the next question", () => {
+  const state = openEditor(nestedDocument);
+  const moved = movePart(state.questions, "part-b", 1);
+
+  // part-b leaves question 1 and lands at the START of question 2, so it keeps
+  // its place in reading order rather than jumping behind part-c.
+  assert.deepEqual(
+    moved.map((question) => question.parts.map((part) => part.id)),
+    [["part-a"], ["part-b", "part-c"]],
+  );
+});
+
+test("moving a part up past the first one enters the previous question", () => {
+  const state = openEditor(nestedDocument);
+  const moved = movePart(state.questions, "part-c", -1);
+
+  // Moving up lands at the END of the question above, again preserving order.
+  assert.deepEqual(
+    moved.map((question) => question.parts.map((part) => part.id)),
+    [["part-a", "part-b", "part-c"], []],
+  );
+});
+
+test("a moved part keeps the id and rubric its grades resolve through", () => {
+  const state = openEditor(nestedDocument);
+  const before = state.questions[0]?.parts[0];
+  const moved = movePart(state.questions, "part-a", 1);
+  const after = moved[0]?.parts.find((part) => part.id === "part-a");
+
+  // Same object, so the id every stored response and grade is keyed by is
+  // untouched. Rebuilding the part here would orphan its submissions.
+  assert.equal(after, before);
+  assert.deepEqual(
+    after?.criteria.map((criterion) => criterion.points),
+    [2],
+  );
+
+  // Only its label changes, and only because labels are positional.
+  const saved = buildTemplatePayload({ ...state, questions: moved });
+
+  assert.deepEqual(
+    saved.questions[0]?.parts.map((part) => [part.id, part.title]),
+    [
+      ["part-b", "A"],
+      ["part-a", "B"],
+    ],
+  );
+});
+
+test("moving within a question swaps neighbours without leaving it", () => {
+  const state = openEditor(nestedDocument);
+  const moved = movePart(state.questions, "part-a", 1);
+
+  assert.deepEqual(
+    moved.map((question) => question.parts.map((part) => part.id)),
+    [["part-b", "part-a"], ["part-c"]],
+  );
+});
+
+test("the first and last parts of the exam have nowhere further to go", () => {
+  const { questions } = openEditor(nestedDocument);
+
+  assert.equal(canMovePart(questions, "part-a", -1), false);
+  assert.equal(canMovePart(questions, "part-c", 1), false);
+
+  assert.equal(canMovePart(questions, "part-a", 1), true);
+  assert.equal(canMovePart(questions, "part-b", -1), true);
+  assert.equal(canMovePart(questions, "part-c", -1), true);
+
+  // A part that is not in the exam cannot move, and moving it is a no-op
+  // rather than a crash.
+  assert.equal(canMovePart(questions, "missing", 1), false);
+  assert.equal(movePart(questions, "missing", 1), questions);
+});
+
+test("moving off either end of the exam changes nothing", () => {
+  const { questions } = openEditor(nestedDocument);
+
+  assert.equal(movePart(questions, "part-a", -1), questions);
+  assert.equal(movePart(questions, "part-c", 1), questions);
+});
+
+test("a legacy document opens as one editable question", () => {
+  const state = openEditor({
+    title: "Old FRQ",
+    directions: "<p>Old stimulus.</p>",
+    questions: [
+      { id: "p1", title: "A", prompt: "<p>One.</p>" },
+      { id: "p2", title: "B", prompt: "<p>Two.</p>" },
+    ],
+  });
+
+  assert.equal(state.questions.length, 1);
+  assert.deepEqual(
+    state.questions[0]?.parts.map((part) => part.id),
+    ["p1", "p2"],
+  );
+  // Exam-wide directions stay exam-wide; the wrap does not steal them into the
+  // question's stimulus, which is what keeps the legacy render unchanged.
+  assert.equal(state.description.question.value, "<p>Old stimulus.</p>");
+  assert.equal(state.questions[0]?.stimulus.question.value, "");
+});
+
+test("an FRQ with no questions still opens with somewhere to add a part", () => {
+  const state = openEditor({ title: "Empty FRQ" });
+
+  assert.equal(state.questions.length, 1);
+  assert.deepEqual(state.questions[0]?.parts, []);
+
+  // An empty question saves as the nested shape, not as a legacy document.
+  const reloaded = normalizeFrqTemplate(
+    buildTemplatePayload(state),
+    identity,
+  );
+
+  assert.equal(reloaded.questions.length, 1);
+  assert.deepEqual(reloaded.questions[0]?.parts, []);
+});

--- a/scripts/frq-roundtrip.test.ts
+++ b/scripts/frq-roundtrip.test.ts
@@ -1,44 +1,26 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  buildInitialState,
+  buildTemplatePayload,
+} from "../src/lib/frq/editorState.ts";
+import {
   LEGACY_QUESTION_ID,
   getAllParts,
-  getPartLabel,
   normalizeFrqTemplate,
 } from "../src/lib/frq/template.ts";
 
 const identity = { id: "t1", subject: "calc", unitId: "u1" };
 
 /**
- * Mirrors buildTemplatePayload in editorRenderer.tsx: the editor holds a flat
- * part list and writes it back wrapped in one question. Kept in step with that
- * function by shape, so this exercises the real save format.
+ * Opening the editor on a template and pressing Save, using the same two
+ * functions the editor itself calls. This used to re-implement the save format
+ * by hand, which meant the round trip could keep passing after the real editor
+ * started writing something else.
  */
 const simulateEditorSave = (
   template: ReturnType<typeof normalizeFrqTemplate>,
-) => ({
-  title: template.title,
-  directions: template.directions,
-  directionsFiles: template.directionsFiles,
-  timeLimitMinutes: template.timeLimitMinutes,
-  isPublic: template.isPublic,
-  questions: [
-    {
-      id: LEGACY_QUESTION_ID,
-      stimulus: "",
-      stimulusFiles: [],
-      parts: getAllParts(template).map((part, index) => ({
-        id: part.id,
-        title: getPartLabel(index),
-        prompt: part.prompt,
-        promptFiles: part.promptFiles,
-        answerType: part.answerType,
-        status: part.status,
-        criteria: part.criteria,
-      })),
-    },
-  ],
-});
+) => buildTemplatePayload(buildInitialState(template));
 
 // A realistic pre-migration document: flat parts, stimulus in `directions`,
 // mixed statuses, real criteria.

--- a/scripts/frq-template.test.ts
+++ b/scripts/frq-template.test.ts
@@ -132,6 +132,33 @@ test("a nested document is read as authored", () => {
   assert.equal(out.sectionSubtitle, "Short answer");
 });
 
+test("an unconfigured section heading is absent, not blank", () => {
+  const identity = { id: "t1", subject: "calc", unitId: "u1" };
+
+  // A `??` fallback is the shape PR 3 uses to reach the hardcoded default. It
+  // only reaches it if the key is missing, so assert the key, not the value.
+  const older = normalizeFrqTemplate({ title: "Old FRQ" }, identity);
+
+  assert.equal("sectionLabel" in older, false);
+  assert.equal("sectionSubtitle" in older, false);
+  assert.equal(older.sectionLabel ?? "Section II", "Section II");
+
+  // A stored blank means the author cleared the field; it reads the same as
+  // never having set it, so the two cannot drift apart downstream.
+  const blanked = normalizeFrqTemplate(
+    { sectionLabel: "", sectionSubtitle: "   " },
+    identity,
+  );
+
+  assert.equal("sectionLabel" in blanked, false);
+  assert.equal("sectionSubtitle" in blanked, false);
+
+  // Non-string junk must not survive as a heading either.
+  const junk = normalizeFrqTemplate({ sectionLabel: 42 }, identity);
+
+  assert.equal(junk.sectionLabel, undefined);
+});
+
 test("parts with no stable id are dropped in both shapes", () => {
   const identity = { id: "t1", subject: "calc", unitId: "u1" };
 

--- a/src/components/frq/editor/partCard.tsx
+++ b/src/components/frq/editor/partCard.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+import RichPromptEditor from "@/components/frq/editor/richPromptEditor";
+import {
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Textarea } from "@/components/ui/textarea";
+import type { EditorPart } from "@/lib/frq/editorState";
+import { formatPoints, getEditorPartPoints } from "@/lib/frq/editorState";
+import { makeId } from "@/lib/frq/template";
+import { ChevronDown, ChevronUp, Info, Plus, Trash2 } from "lucide-react";
+
+interface PartCardProps {
+  part: EditorPart;
+  /** Display label within its question, restarting at A for each question. */
+  label: string;
+  onChange: (updater: (part: EditorPart) => EditorPart) => void;
+  onDelete: () => void;
+  onMove: (direction: -1 | 1) => void;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+}
+
+const PartCard = ({
+  part,
+  label,
+  onChange,
+  onDelete,
+  onMove,
+  canMoveUp,
+  canMoveDown,
+}: PartCardProps) => {
+  const addCriterion = () => {
+    onChange((current) => ({
+      ...current,
+      criteria: [
+        ...current.criteria,
+        { id: makeId("criterion"), description: "", points: 1 },
+      ],
+    }));
+  };
+
+  const updateCriterion = (
+    criterionId: string,
+    changes: { description?: string; points?: number },
+  ) => {
+    onChange((current) => ({
+      ...current,
+      criteria: current.criteria.map((criterion) =>
+        criterion.id === criterionId ? { ...criterion, ...changes } : criterion,
+      ),
+    }));
+  };
+
+  const deleteCriterion = (criterionId: string) => {
+    onChange((current) => ({
+      ...current,
+      criteria: current.criteria.filter(
+        (criterion) => criterion.id !== criterionId,
+      ),
+    }));
+  };
+
+  return (
+    <AccordionItem
+      value={part.id}
+      data-frq-part={part.id}
+      className="rounded-lg border bg-background px-4 shadow-sm"
+    >
+      <AccordionTrigger variant="secondary" className="mr-0 py-4 hover:no-underline">
+        <div className="flex flex-1 items-center justify-between pr-3">
+          <span className="flex items-center gap-2">
+            <span className="font-semibold">Part {label}</span>
+
+            {part.status === "legacy" && (
+              <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Legacy
+              </span>
+            )}
+          </span>
+          <span className="text-sm font-normal text-muted-foreground">
+            {formatPoints(getEditorPartPoints(part))}
+          </span>
+        </div>
+      </AccordionTrigger>
+
+      {/* ui/accordion.tsx hardcodes opacity-70 on the content root and routes
+          className to an inner div, so there is no class-based override.
+          Without this the editor's inputs all render washed out. Remove once
+          accordion.tsx exposes it. */}
+      <AccordionContent
+        style={{ opacity: 1 }}
+        className="space-y-5 pb-5 text-foreground"
+      >
+        <div>
+          <label className="text-sm font-medium">Part prompt</label>
+          <div className="mt-2">
+            <RichPromptEditor
+              value={part.prompt}
+              onChange={(prompt) =>
+                onChange((current) => ({ ...current, prompt }))
+              }
+              placeholder="Enter the prompt for this part here."
+            />
+          </div>
+        </div>
+
+        {/* No part-level points field: the total is derived from the grading
+            criteria below, which is what the grader actually awards against. */}
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div>
+            <label className="text-sm font-medium">Input type</label>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="mt-2 w-full justify-between"
+                >
+                  {part.answerType === "text" ? "Text" : "Equation"}
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start">
+                <DropdownMenuRadioGroup
+                  value={part.answerType}
+                  onValueChange={(value) => {
+                    if (value !== "text" && value !== "equation") {
+                      return;
+                    }
+
+                    onChange((current) => ({ ...current, answerType: value }));
+                  }}
+                >
+                  <DropdownMenuRadioItem value="text">Text</DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="equation">
+                    Equation
+                  </DropdownMenuRadioItem>
+                </DropdownMenuRadioGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+
+          <div>
+            <label className="text-sm font-medium">Status</label>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="mt-2 w-full justify-between"
+                >
+                  {part.status === "public" ? "Public" : "Legacy"}
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start">
+                <DropdownMenuRadioGroup
+                  value={part.status}
+                  onValueChange={(value) => {
+                    if (value !== "public" && value !== "legacy") {
+                      return;
+                    }
+
+                    onChange((current) => ({ ...current, status: value }));
+                  }}
+                >
+                  <DropdownMenuRadioItem value="public">
+                    Public
+                  </DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="legacy">
+                    Legacy
+                  </DropdownMenuRadioItem>
+                </DropdownMenuRadioGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 border-t pt-4">
+          <Button type="button" variant="outline" onClick={addCriterion}>
+            <Plus className="mr-2 size-4" />
+            Add Criteria
+          </Button>
+
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                type="button"
+                variant="outline"
+                aria-label="Part information"
+                className="px-3"
+              >
+                <Info className="size-4" />
+              </Button>
+            </PopoverTrigger>
+
+            <PopoverContent align="start" className="w-72 text-sm">
+              A part&apos;s point total is calculated from its grading criteria.
+              Graders award points against these exact lines.
+            </PopoverContent>
+          </Popover>
+
+          {/* Moving past either end of a question carries the part into the
+              neighbouring one, which is how an existing flat FRQ gets split
+              into real questions without retyping a prompt. */}
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onMove(-1)}
+            disabled={!canMoveUp}
+            aria-label={`Move part ${label} up`}
+            title="Move up, into the previous question if this is the first part"
+            className="px-3"
+          >
+            <ChevronUp className="size-4" />
+          </Button>
+
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onMove(1)}
+            disabled={!canMoveDown}
+            aria-label={`Move part ${label} down`}
+            title="Move down, into the next question if this is the last part"
+            className="px-3"
+          >
+            <ChevronDown className="size-4" />
+          </Button>
+
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onDelete}
+            title="Delete this part"
+            className="ml-auto text-destructive"
+          >
+            <Trash2 className="mr-2 size-4" />
+            Delete Part
+          </Button>
+        </div>
+
+        <div className="space-y-3">
+          <h4 className="text-sm font-semibold">Grading Criteria</h4>
+
+          {part.criteria.length === 0 ? (
+            <p className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+              No grading criteria have been added. A part with no criteria is
+              worth zero points.
+            </p>
+          ) : (
+            part.criteria.map((criterion, criterionIndex) => (
+              <div
+                key={criterion.id}
+                className="grid gap-3 rounded-md border bg-muted/20 p-4 md:grid-cols-[minmax(0,1fr)_7rem_auto]"
+              >
+                <div>
+                  <label className="text-sm font-medium">
+                    Criterion {criterionIndex + 1}
+                  </label>
+                  <Textarea
+                    value={criterion.description}
+                    onChange={(event) =>
+                      updateCriterion(criterion.id, {
+                        description: event.target.value,
+                      })
+                    }
+                    placeholder="Describe what earns these points."
+                    className="mt-2 min-h-24"
+                  />
+                </div>
+
+                <div>
+                  <label className="text-sm font-medium">Points</label>
+                  <Input
+                    type="number"
+                    min={0}
+                    step={1}
+                    value={criterion.points}
+                    onChange={(event) =>
+                      updateCriterion(criterion.id, {
+                        points: Math.max(0, Number(event.target.value) || 0),
+                      })
+                    }
+                    className="mt-2"
+                  />
+                </div>
+
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => deleteCriterion(criterion.id)}
+                  title="Delete criterion"
+                  aria-label={`Delete criterion ${criterionIndex + 1}`}
+                  className="mt-7 size-10 p-0 text-destructive"
+                >
+                  <Trash2 className="size-4" />
+                </Button>
+              </div>
+            ))
+          )}
+        </div>
+      </AccordionContent>
+    </AccordionItem>
+  );
+};
+
+export default PartCard;

--- a/src/components/frq/editor/partCard.tsx
+++ b/src/components/frq/editor/partCard.tsx
@@ -83,7 +83,10 @@ const PartCard = ({
       data-frq-part={part.id}
       className="rounded-lg border bg-background px-4 shadow-sm"
     >
-      <AccordionTrigger variant="secondary" className="mr-0 py-4 hover:no-underline">
+      <AccordionTrigger
+        variant="secondary"
+        className="mr-0 py-4 hover:no-underline"
+      >
         <div className="flex flex-1 items-center justify-between pr-3">
           <span className="flex items-center gap-2">
             <span className="font-semibold">Part {label}</span>
@@ -147,7 +150,9 @@ const PartCard = ({
                     onChange((current) => ({ ...current, answerType: value }));
                   }}
                 >
-                  <DropdownMenuRadioItem value="text">Text</DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="text">
+                    Text
+                  </DropdownMenuRadioItem>
                   <DropdownMenuRadioItem value="equation">
                     Equation
                   </DropdownMenuRadioItem>

--- a/src/components/frq/editor/questionCard.tsx
+++ b/src/components/frq/editor/questionCard.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import PartCard from "@/components/frq/editor/partCard";
+import RichPromptEditor from "@/components/frq/editor/richPromptEditor";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Button } from "@/components/ui/button";
+import type { EditorPart, EditorQuestion } from "@/lib/frq/editorState";
+import {
+  createEditorPart,
+  formatPoints,
+  getEditorQuestionPoints,
+} from "@/lib/frq/editorState";
+import { getPartLabel } from "@/lib/frq/template";
+import { Plus, Trash2 } from "lucide-react";
+
+interface QuestionCardProps {
+  question: EditorQuestion;
+  /** Zero-based position; questions are numbered 1, 2, 3 for the author. */
+  index: number;
+  onChange: (updater: (question: EditorQuestion) => EditorQuestion) => void;
+  onDelete: () => void;
+  onMovePart: (partId: string, direction: -1 | 1) => void;
+  canMovePart: (partId: string, direction: -1 | 1) => boolean;
+  canDelete: boolean;
+}
+
+const QuestionCard = ({
+  question,
+  index,
+  onChange,
+  onDelete,
+  onMovePart,
+  canMovePart,
+  canDelete,
+}: QuestionCardProps) => {
+  const updatePart = (
+    partId: string,
+    updater: (part: EditorPart) => EditorPart,
+  ) => {
+    onChange((current) => ({
+      ...current,
+      parts: current.parts.map((part) =>
+        part.id === partId ? updater(part) : part,
+      ),
+    }));
+  };
+
+  const addPart = () => {
+    onChange((current) => ({
+      ...current,
+      parts: [...current.parts, createEditorPart()],
+    }));
+  };
+
+  const deletePart = (partId: string) => {
+    onChange((current) => ({
+      ...current,
+      parts: current.parts.filter((part) => part.id !== partId),
+    }));
+  };
+
+  return (
+    <AccordionItem
+      value={question.id}
+      data-frq-question={question.id}
+      className="rounded-lg border-2 bg-muted/30 px-4 shadow-sm"
+    >
+      <AccordionTrigger className="py-4 hover:no-underline">
+        <div className="flex flex-1 items-center justify-between pr-3">
+          <span className="text-lg font-semibold">Question {index + 1}</span>
+          <span className="text-sm font-normal text-muted-foreground">
+            {question.parts.length}{" "}
+            {question.parts.length === 1 ? "part" : "parts"} &middot;{" "}
+            {formatPoints(getEditorQuestionPoints(question))}
+          </span>
+        </div>
+      </AccordionTrigger>
+
+      {/* See partCard.tsx: ui/accordion.tsx hardcodes opacity-70 on the content
+          root, and there is no class-based override. */}
+      <AccordionContent
+        style={{ opacity: 1 }}
+        className="space-y-5 pb-5 text-foreground"
+      >
+        <div>
+          <label className="text-sm font-medium">Question stimulus</label>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Source material for this question only. Students see it beside every
+            part of this question. Directions that apply to the whole FRQ belong
+            in the description on the left.
+          </p>
+          <div className="mt-2">
+            <RichPromptEditor
+              value={question.stimulus}
+              onChange={(stimulus) =>
+                onChange((current) => ({ ...current, stimulus }))
+              }
+              placeholder="Enter the stimulus for this question here."
+            />
+          </div>
+        </div>
+
+        {question.parts.length === 0 ? (
+          <p className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+            This question has no parts yet. A question with no parts is not shown
+            to students.
+          </p>
+        ) : (
+          <Accordion
+            type="multiple"
+            defaultValue={question.parts.map((part) => part.id)}
+            className="space-y-3"
+          >
+            {question.parts.map((part, partIndex) => (
+              <PartCard
+                key={part.id}
+                part={part}
+                // Labels restart at A inside every question, which is how AP
+                // numbers them.
+                label={getPartLabel(partIndex)}
+                onChange={(updater) => updatePart(part.id, updater)}
+                onDelete={() => deletePart(part.id)}
+                onMove={(direction) => onMovePart(part.id, direction)}
+                canMoveUp={canMovePart(part.id, -1)}
+                canMoveDown={canMovePart(part.id, 1)}
+              />
+            ))}
+          </Accordion>
+        )}
+
+        <div className="flex flex-wrap items-center gap-2 border-t pt-4">
+          <Button type="button" variant="outline" onClick={addPart}>
+            <Plus className="mr-2 size-4" />
+            Add Part
+          </Button>
+
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onDelete}
+            disabled={!canDelete}
+            title={
+              canDelete
+                ? "Delete this question and every part in it"
+                : "An FRQ needs at least one question"
+            }
+            className="ml-auto text-destructive"
+          >
+            <Trash2 className="mr-2 size-4" />
+            Delete Question
+          </Button>
+        </div>
+      </AccordionContent>
+    </AccordionItem>
+  );
+};
+
+export default QuestionCard;

--- a/src/components/frq/editor/questionCard.tsx
+++ b/src/components/frq/editor/questionCard.tsx
@@ -107,8 +107,8 @@ const QuestionCard = ({
 
         {question.parts.length === 0 ? (
           <p className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
-            This question has no parts yet. A question with no parts is not shown
-            to students.
+            This question has no parts yet. A question with no parts is not
+            shown to students.
           </p>
         ) : (
           <Accordion

--- a/src/components/frq/editor/questionCard.tsx
+++ b/src/components/frq/editor/questionCard.tsx
@@ -11,7 +11,6 @@ import {
 import { Button } from "@/components/ui/button";
 import type { EditorPart, EditorQuestion } from "@/lib/frq/editorState";
 import {
-  createEditorPart,
   formatPoints,
   getEditorQuestionPoints,
 } from "@/lib/frq/editorState";
@@ -22,11 +21,26 @@ interface QuestionCardProps {
   question: EditorQuestion;
   /** Zero-based position; questions are numbered 1, 2, 3 for the author. */
   index: number;
+  /** Edits this question's own fields. Its parts are addressed separately. */
   onChange: (updater: (question: EditorQuestion) => EditorQuestion) => void;
   onDelete: () => void;
+  onAddPart: () => void;
+  /**
+   * Part handlers take a part id and live in the editor, not here. A part can
+   * move to another question while an edit to it is still in flight, so an
+   * update scoped to the question this card renders would land nowhere.
+   */
+  onUpdatePart: (
+    partId: string,
+    updater: (part: EditorPart) => EditorPart,
+  ) => void;
+  onDeletePart: (partId: string) => void;
   onMovePart: (partId: string, direction: -1 | 1) => void;
   canMovePart: (partId: string, direction: -1 | 1) => boolean;
   canDelete: boolean;
+  /** Open part ids across the whole FRQ; part ids are unique per document. */
+  openParts: string[];
+  onOpenPartsChange: (openParts: string[]) => void;
 }
 
 const QuestionCard = ({
@@ -34,36 +48,15 @@ const QuestionCard = ({
   index,
   onChange,
   onDelete,
+  onAddPart,
+  onUpdatePart,
+  onDeletePart,
   onMovePart,
   canMovePart,
   canDelete,
+  openParts,
+  onOpenPartsChange,
 }: QuestionCardProps) => {
-  const updatePart = (
-    partId: string,
-    updater: (part: EditorPart) => EditorPart,
-  ) => {
-    onChange((current) => ({
-      ...current,
-      parts: current.parts.map((part) =>
-        part.id === partId ? updater(part) : part,
-      ),
-    }));
-  };
-
-  const addPart = () => {
-    onChange((current) => ({
-      ...current,
-      parts: [...current.parts, createEditorPart()],
-    }));
-  };
-
-  const deletePart = (partId: string) => {
-    onChange((current) => ({
-      ...current,
-      parts: current.parts.filter((part) => part.id !== partId),
-    }));
-  };
-
   return (
     <AccordionItem
       value={question.id}
@@ -113,7 +106,18 @@ const QuestionCard = ({
         ) : (
           <Accordion
             type="multiple"
-            defaultValue={question.parts.map((part) => part.id)}
+            value={openParts}
+            // This accordion reports only the parts it owns, so the ids of
+            // every other question's open parts have to be carried across or
+            // opening one part would collapse the rest of the FRQ.
+            onValueChange={(next) => {
+              const owned = new Set(question.parts.map((part) => part.id));
+
+              onOpenPartsChange([
+                ...openParts.filter((id) => !owned.has(id)),
+                ...next,
+              ]);
+            }}
             className="space-y-3"
           >
             {question.parts.map((part, partIndex) => (
@@ -123,8 +127,8 @@ const QuestionCard = ({
                 // Labels restart at A inside every question, which is how AP
                 // numbers them.
                 label={getPartLabel(partIndex)}
-                onChange={(updater) => updatePart(part.id, updater)}
-                onDelete={() => deletePart(part.id)}
+                onChange={(updater) => onUpdatePart(part.id, updater)}
+                onDelete={() => onDeletePart(part.id)}
                 onMove={(direction) => onMovePart(part.id, direction)}
                 canMoveUp={canMovePart(part.id, -1)}
                 canMoveDown={canMovePart(part.id, 1)}
@@ -134,7 +138,7 @@ const QuestionCard = ({
         )}
 
         <div className="flex flex-wrap items-center gap-2 border-t pt-4">
-          <Button type="button" variant="outline" onClick={addPart}>
+          <Button type="button" variant="outline" onClick={onAddPart}>
             <Plus className="mr-2 size-4" />
             Add Part
           </Button>

--- a/src/components/frq/editor/richPromptEditor.tsx
+++ b/src/components/frq/editor/richPromptEditor.tsx
@@ -16,22 +16,28 @@ interface RichPromptEditorProps {
  * AdvancedTextbox is written for a single flat array of questions: it reads
  * `questions[qIndex]` and hands the whole array back on every change, rebuilt
  * from the array it captured when that change started. A file upload finishes
- * long after it began, so the array it hands back is stale, and writing all of
- * it back would undo edits made to the other entries meanwhile.
+ * long after it began, so the array it hands back is stale.
  *
- * Giving every field its own one-entry array removes the hazard rather than
- * working around it: overwriting a sibling requires a sibling to be in the
- * array, and here there is never one. That is what makes nesting parts inside
- * questions safe, instead of doubling a hazard the flat editor already had.
+ * Giving every field its own one-entry array fixes the CROSS-FIELD half of
+ * that: overwriting a sibling takes a sibling in the array, and here there is
+ * never one. Nesting parts inside questions is therefore no more dangerous
+ * than the flat editor was.
+ *
+ * It does NOT fix the within-field half, which AdvancedTextbox still has and
+ * this component cannot reach. `updateQuestionsWithFiles` rebuilds the value
+ * from the `questionInstance` its closure captured, so text typed while an
+ * upload is in flight is reverted when that upload resolves. Closing it means
+ * changing how AdvancedTextbox writes back, which every article-creator screen
+ * also depends on. Do not read the isolation here as covering that case.
  */
 const RichPromptEditor = ({
   value,
   onChange,
   placeholder,
 }: RichPromptEditorProps) => {
-  // Identity has to survive unrelated re-renders. AdvancedTextbox re-seeds its
-  // local text buffer from this entry in an effect keyed on it, so handing it a
-  // freshly built array every render would reset the buffer mid-edit.
+  // Only to avoid handing a new array identity down on every render.
+  // AdvancedTextbox's sync effect keys on `questions[qIndex]`, which is `value`
+  // itself, so the array's identity is not what guards the text buffer.
   const questions = useMemo(() => [value], [value]);
 
   return (

--- a/src/components/frq/editor/richPromptEditor.tsx
+++ b/src/components/frq/editor/richPromptEditor.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import AdvancedTextbox from "@/components/article-creator/custom_questions/AdvancedTextbox";
+import type { QuestionFormat } from "@/types/questions";
+import { useMemo } from "react";
+
+interface RichPromptEditorProps {
+  value: QuestionFormat;
+  onChange: (value: QuestionFormat) => void;
+  placeholder?: string;
+}
+
+/**
+ * One rich-text field, isolated from every other one on the page.
+ *
+ * AdvancedTextbox is written for a single flat array of questions: it reads
+ * `questions[qIndex]` and hands the whole array back on every change, rebuilt
+ * from the array it captured when that change started. A file upload finishes
+ * long after it began, so the array it hands back is stale, and writing all of
+ * it back would undo edits made to the other entries meanwhile.
+ *
+ * Giving every field its own one-entry array removes the hazard rather than
+ * working around it: overwriting a sibling requires a sibling to be in the
+ * array, and here there is never one. That is what makes nesting parts inside
+ * questions safe, instead of doubling a hazard the flat editor already had.
+ */
+const RichPromptEditor = ({
+  value,
+  onChange,
+  placeholder,
+}: RichPromptEditorProps) => {
+  // Identity has to survive unrelated re-renders. AdvancedTextbox re-seeds its
+  // local text buffer from this entry in an effect keyed on it, so handing it a
+  // freshly built array every render would reset the buffer mid-edit.
+  const questions = useMemo(() => [value], [value]);
+
+  return (
+    <AdvancedTextbox
+      questions={questions}
+      setQuestions={(updated) => {
+        const next = updated[0];
+
+        if (next) {
+          onChange(next);
+        }
+      }}
+      origin="question"
+      qIndex={0}
+      placeholder={placeholder}
+    />
+  );
+};
+
+export default RichPromptEditor;

--- a/src/components/frq/editorFooter.tsx
+++ b/src/components/frq/editorFooter.tsx
@@ -20,6 +20,13 @@ interface FRQEditorFooterProps {
   frqName: string;
   visibility: FRQVisibility;
   hasUnsavedChanges: boolean;
+  /**
+   * Reveals and scrolls to a part. The editor owns this rather than the footer
+   * because a part sits inside its question's accordion panel: while that
+   * question is collapsed the part is not in the DOM at all, so the footer
+   * cannot find it to scroll to. The editor opens both first.
+   */
+  onSelectPart: (partId: string) => void;
 }
 
 /**
@@ -32,16 +39,15 @@ const FRQEditorFooter = ({
   frqName,
   visibility,
   hasUnsavedChanges,
+  onSelectPart,
 }: FRQEditorFooterProps) => {
   // Controlled so picking a part closes the panel instead of leaving it parked
   // over the footer, matching frq/FRQFooter.tsx on the other FRQ pages.
   const [navigationOpen, setNavigationOpen] = useState(false);
 
-  const scrollToPart = (partId: string) => {
+  const selectPart = (partId: string) => {
     setNavigationOpen(false);
-    document
-      .querySelector(`[data-frq-part="${partId}"]`)
-      ?.scrollIntoView({ behavior: "smooth", block: "start" });
+    onSelectPart(partId);
   };
 
   return (
@@ -78,7 +84,7 @@ const FRQEditorFooter = ({
                     key={part.id}
                     type="button"
                     aria-label={`Go to part ${part.label}`}
-                    onClick={() => scrollToPart(part.id)}
+                    onClick={() => selectPart(part.id)}
                     className="flex size-8 items-center justify-center border-2 border-dotted border-gray-400 font-medium text-[#2a47bb] hover:bg-blue-50"
                   >
                     {part.label}

--- a/src/components/frq/editorRenderer.tsx
+++ b/src/components/frq/editorRenderer.tsx
@@ -7,22 +7,30 @@ import { Accordion } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { getFrqTemplateDocRef } from "@/lib/firestore/frqRefs";
-import type { EditorQuestion, EditorState } from "@/lib/frq/editorState";
+import type {
+  EditorPart,
+  EditorQuestion,
+  EditorState,
+} from "@/lib/frq/editorState";
 import {
   buildInitialState,
   buildTemplatePayload,
   canMovePart,
+  createEditorPart,
   createEditorQuestion,
+  deletePartById,
   formatPoints,
   getEditorTotalPoints,
+  locatePart,
   movePart,
+  updatePartById,
 } from "@/lib/frq/editorState";
 import { getPartLabel } from "@/lib/frq/template";
 import type { FRQTemplate } from "@/types/frq";
 import type { QuestionFormat } from "@/types/questions";
 import { deleteField, serverTimestamp, updateDoc } from "firebase/firestore";
 import { Clock3, Plus, Save } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 interface FRQEditorRendererProps {
   frqFound: boolean;
@@ -51,7 +59,9 @@ const FRQEditorRenderer = ({
   frqFound,
   frqTemplate,
 }: FRQEditorRendererProps) => {
-  const initialState = useRef(buildInitialState(frqTemplate)).current;
+  // Lazy: useRef(buildInitialState(...)) would rebuild the state on every
+  // render and throw it away, minting a wasted question id each time.
+  const [initialState] = useState(() => buildInitialState(frqTemplate));
 
   const [title, setTitle] = useState(initialState.title);
   const [description, setDescription] = useState<QuestionFormat>(
@@ -68,6 +78,19 @@ const FRQEditorRenderer = ({
     initialState.timeLimitMinutes,
   );
   const [isPublic, setIsPublic] = useState(initialState.isPublic);
+
+  // Both accordions are controlled. With Radix's uncontrolled `defaultValue`
+  // the open list is read once at mount, so anything added or moved afterwards
+  // renders collapsed: "Add Part" would look broken, and a part moved into a
+  // collapsed question would disappear from the page the moment it was moved.
+  const [openQuestions, setOpenQuestions] = useState(() =>
+    initialState.questions.map((question) => question.id),
+  );
+  const [openParts, setOpenParts] = useState(() =>
+    initialState.questions.flatMap((question) =>
+      question.parts.map((part) => part.id),
+    ),
+  );
 
   const [saveState, setSaveState] = useState<SaveState>("idle");
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -127,14 +150,87 @@ const FRQEditorRenderer = ({
     );
   };
 
+  const reveal = (
+    setOpen: typeof setOpenQuestions,
+    id: string,
+  ) => setOpen((open) => (open.includes(id) ? open : [...open, id]));
+
   const addQuestion = () => {
-    setQuestions((current) => [...current, createEditorQuestion()]);
+    const question = createEditorQuestion();
+
+    setQuestions((current) => [...current, question]);
+    reveal(setOpenQuestions, question.id);
   };
 
   const deleteQuestion = (questionId: string) => {
     setQuestions((current) =>
       current.filter((question) => question.id !== questionId),
     );
+  };
+
+  const addPart = (questionId: string) => {
+    const part = createEditorPart();
+
+    setQuestions((current) =>
+      current.map((question) =>
+        question.id === questionId
+          ? { ...question, parts: [...question.parts, part] }
+          : question,
+      ),
+    );
+    reveal(setOpenParts, part.id);
+  };
+
+  // Part edits address the part by id, never by the question it sat in when
+  // this handler was created. A part can change parent mid-edit: an upload
+  // started in question 1 can resolve after the author moved that part into
+  // question 2, and a question-scoped update would then match nothing and
+  // silently drop the file's download URL.
+  const updatePart = (
+    partId: string,
+    updater: (part: EditorPart) => EditorPart,
+  ) => {
+    setQuestions((current) => updatePartById(current, partId, updater));
+  };
+
+  const deletePart = (partId: string) => {
+    setQuestions((current) => deletePartById(current, partId));
+  };
+
+  const movePartBy = (partId: string, direction: -1 | 1) => {
+    // Computed outside the updater: revealing is a second state write, and
+    // React invokes updaters twice in StrictMode.
+    const next = movePart(questions, partId, direction);
+    const landed = locatePart(next, partId);
+    const questionId = landed ? next[landed.questionIndex]?.id : undefined;
+
+    setQuestions(next);
+
+    // Open wherever it landed, or a move into a collapsed question reads as
+    // the part vanishing off the page.
+    if (questionId) {
+      reveal(setOpenQuestions, questionId);
+      reveal(setOpenParts, partId);
+    }
+  };
+
+  /** Reveal a part the footer jumped to, then scroll once it is mounted. */
+  const selectPart = (partId: string) => {
+    const location = locatePart(questions, partId);
+    const questionId = location ? questions[location.questionIndex]?.id : null;
+
+    if (!questionId) {
+      return;
+    }
+
+    reveal(setOpenQuestions, questionId);
+    reveal(setOpenParts, partId);
+
+    requestAnimationFrame(() => {
+      document
+        .querySelector(`[data-frq-part="${partId}"]`)
+        ?.scrollIntoView({ behavior: "smooth", block: "start" });
+    });
   };
 
   const saveTemplate = useCallback(async () => {
@@ -351,7 +447,8 @@ const FRQEditorRenderer = ({
 
             <Accordion
               type="multiple"
-              defaultValue={questions.map((question) => question.id)}
+              value={openQuestions}
+              onValueChange={setOpenQuestions}
               className="space-y-4"
             >
               {questions.map((question, questionIndex) => (
@@ -361,15 +458,16 @@ const FRQEditorRenderer = ({
                   index={questionIndex}
                   onChange={(updater) => updateQuestion(question.id, updater)}
                   onDelete={() => deleteQuestion(question.id)}
-                  onMovePart={(partId, direction) =>
-                    setQuestions((current) =>
-                      movePart(current, partId, direction),
-                    )
-                  }
+                  onAddPart={() => addPart(question.id)}
+                  onUpdatePart={updatePart}
+                  onDeletePart={deletePart}
+                  onMovePart={movePartBy}
                   canMovePart={(partId, direction) =>
                     canMovePart(questions, partId, direction)
                   }
                   canDelete={questions.length > 1}
+                  openParts={openParts}
+                  onOpenPartsChange={setOpenParts}
                 />
               ))}
             </Accordion>
@@ -389,6 +487,7 @@ const FRQEditorRenderer = ({
         frqName={title.trim() || "Untitled FRQ"}
         visibility={isPublic ? "public" : "private"}
         hasUnsavedChanges={hasUnsavedChanges}
+        onSelectPart={selectPart}
       />
     </div>
   );

--- a/src/components/frq/editorRenderer.tsx
+++ b/src/components/frq/editorRenderer.tsx
@@ -1,57 +1,31 @@
 "use client";
 
-import AdvancedTextbox from "@/components/article-creator/custom_questions/AdvancedTextbox";
 import FRQEditorFooter from "@/components/frq/editorFooter";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion";
+import QuestionCard from "@/components/frq/editor/questionCard";
+import RichPromptEditor from "@/components/frq/editor/richPromptEditor";
+import { Accordion } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import { Textarea } from "@/components/ui/textarea";
 import { getFrqTemplateDocRef } from "@/lib/firestore/frqRefs";
-import {
-  DEFAULT_TIME_LIMIT_MINUTES,
-  getAllParts,
-  getPartLabel,
-  getPartPoints,
-  LEGACY_QUESTION_ID,
-  makeId,
-  toQuestionInput,
-} from "@/lib/frq/template";
-import type { QuestionFormat, QuestionInput } from "@/types/questions";
-import { serverTimestamp, updateDoc } from "firebase/firestore";
-import { Clock3, Info, Plus, Save, Trash2 } from "lucide-react";
 import type {
-  FRQAnswerType,
-  FRQGradingCriterion,
-  FRQQuestionStatus,
-  FRQTemplate,
-  FRQTemplatePart,
-} from "@/types/frq";
+  EditorQuestion,
+  EditorState,
+} from "@/lib/frq/editorState";
+import {
+  buildInitialState,
+  buildTemplatePayload,
+  canMovePart,
+  createEditorQuestion,
+  formatPoints,
+  getEditorTotalPoints,
+  movePart,
+} from "@/lib/frq/editorState";
+import { getPartLabel } from "@/lib/frq/template";
+import type { FRQTemplate } from "@/types/frq";
+import type { QuestionFormat } from "@/types/questions";
+import { deleteField, serverTimestamp, updateDoc } from "firebase/firestore";
+import { Clock3, Plus, Save } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-
-interface EditorQuestion {
-  id: string;
-  questionData: QuestionFormat;
-  status: FRQQuestionStatus;
-  answerType: FRQAnswerType;
-  criteria: FRQGradingCriterion[];
-}
 
 interface FRQEditorRendererProps {
   frqFound: boolean;
@@ -60,95 +34,18 @@ interface FRQEditorRendererProps {
 
 type SaveState = "idle" | "saving" | "saved" | "error";
 
-const createQuestionInput = (value = ""): QuestionInput => ({
-  value,
-  files: [],
-});
-
-const formatPoints = (points: number) =>
-  `${points} ${points === 1 ? "point" : "points"}`;
-
-const createQuestionData = (
-  question = createQuestionInput(),
-): QuestionFormat => ({
-  question,
-  type: "frq",
-  options: [],
-  answers: [],
-  explanation: createQuestionInput(),
-  content: createQuestionInput(),
-  topic: "",
-});
-
-const createEditorQuestion = (): EditorQuestion => ({
-  id: makeId("question"),
-  questionData: createQuestionData(),
-  status: "public",
-  answerType: "text",
-  criteria: [],
-});
-
-const createEditorQuestionFromTemplate = (
-  templateQuestion: FRQTemplatePart,
-): EditorQuestion => ({
-  id: templateQuestion.id,
-  questionData: createQuestionData(
-    toQuestionInput(templateQuestion.prompt, templateQuestion.promptFiles),
-  ),
-  status: templateQuestion.status ?? "public",
-  answerType: templateQuestion.answerType ?? "text",
-  criteria: templateQuestion.criteria ?? [],
-});
-
-interface EditorState {
-  title: string;
-  description: QuestionInput;
-  questions: EditorQuestion[];
-  timeLimitMinutes: number;
-  isPublic: boolean;
-}
-
-const buildInitialState = (template: FRQTemplate | null): EditorState => ({
-  title: template?.title ?? "",
-  description: toQuestionInput(template?.directions, template?.directionsFiles),
-  questions: (template ? getAllParts(template) : []).map(
-    createEditorQuestionFromTemplate,
-  ),
-  timeLimitMinutes: template?.timeLimitMinutes ?? DEFAULT_TIME_LIMIT_MINUTES,
-  isPublic: template?.isPublic === true,
-});
-
 /**
- * The exact document body a save writes, minus the server timestamp. Unsaved
- * state is detected by comparing this against the last persisted version rather
- * than by watching for state updates: React StrictMode double-invokes effects
- * in development, and the rich-text children re-emit equal values on mount, so
- * a "something changed" listener reported unsaved work before any edit.
+ * Firestore rejects `undefined`, and omitting a key from `updateDoc` leaves
+ * whatever is stored in place — so clearing a section heading has to be written
+ * as an explicit delete, or the old heading outlives the edit that cleared it.
+ * Deleting rather than storing `""` is also what keeps `normalizeFrqTemplate`'s
+ * "absent means unconfigured" rule true of documents this editor writes.
  */
-const buildTemplatePayload = (state: EditorState) => ({
-  title: state.title.trim() || "Untitled FRQ",
-  directions: state.description.value,
-  directionsFiles: state.description.files,
-  timeLimitMinutes: state.timeLimitMinutes,
-  isPublic: state.isPublic,
-  // PR 1 authors a single question; PR 2 adds the question-level UI. Wrapping
-  // here means a save from the current editor already writes the new shape.
-  questions: [
-    {
-      id: LEGACY_QUESTION_ID,
-      stimulus: "",
-      stimulusFiles: [],
-      parts: state.questions.map((question, index) => ({
-        id: question.id,
-        title: getPartLabel(index),
-        prompt: question.questionData.question.value,
-        promptFiles: question.questionData.question.files,
-        answerType: question.answerType,
-        status: question.status,
-        criteria: question.criteria,
-      })),
-    },
-  ],
+const toFirestoreUpdate = (payload: ReturnType<typeof buildTemplatePayload>) => ({
+  ...payload,
+  sectionLabel: payload.sectionLabel || deleteField(),
+  sectionSubtitle: payload.sectionSubtitle || deleteField(),
+  updatedAt: serverTimestamp(),
 });
 
 const FRQEditorRenderer = ({
@@ -158,8 +55,12 @@ const FRQEditorRenderer = ({
   const initialState = useRef(buildInitialState(frqTemplate)).current;
 
   const [title, setTitle] = useState(initialState.title);
-  const [description, setDescription] = useState<QuestionInput>(
+  const [description, setDescription] = useState<QuestionFormat>(
     initialState.description,
+  );
+  const [sectionLabel, setSectionLabel] = useState(initialState.sectionLabel);
+  const [sectionSubtitle, setSectionSubtitle] = useState(
+    initialState.sectionSubtitle,
   );
   const [questions, setQuestions] = useState<EditorQuestion[]>(
     initialState.questions,
@@ -180,11 +81,21 @@ const FRQEditorRenderer = ({
       buildTemplatePayload({
         title,
         description,
+        sectionLabel,
+        sectionSubtitle,
         questions,
         timeLimitMinutes,
         isPublic,
-      }),
-    [title, description, questions, timeLimitMinutes, isPublic],
+      } satisfies EditorState),
+    [
+      title,
+      description,
+      sectionLabel,
+      sectionSubtitle,
+      questions,
+      timeLimitMinutes,
+      isPublic,
+    ],
   );
 
   const hasUnsavedChanges = JSON.stringify(currentPayload) !== savedSignature;
@@ -210,56 +121,21 @@ const FRQEditorRenderer = ({
     questionId: string,
     updater: (question: EditorQuestion) => EditorQuestion,
   ) => {
-    setQuestions((currentQuestions) =>
-      currentQuestions.map((question) =>
+    setQuestions((current) =>
+      current.map((question) =>
         question.id === questionId ? updater(question) : question,
       ),
     );
   };
 
   const addQuestion = () => {
-    setQuestions((currentQuestions) => [
-      ...currentQuestions,
-      createEditorQuestion(),
-    ]);
+    setQuestions((current) => [...current, createEditorQuestion()]);
   };
 
   const deleteQuestion = (questionId: string) => {
-    setQuestions((currentQuestions) =>
-      currentQuestions.filter((question) => question.id !== questionId),
+    setQuestions((current) =>
+      current.filter((question) => question.id !== questionId),
     );
-  };
-
-  const addCriterion = (questionId: string) => {
-    updateQuestion(questionId, (question) => ({
-      ...question,
-      criteria: [
-        ...question.criteria,
-        { id: makeId("criterion"), description: "", points: 1 },
-      ],
-    }));
-  };
-
-  const updateCriterion = (
-    questionId: string,
-    criterionId: string,
-    changes: Partial<Pick<FRQGradingCriterion, "description" | "points">>,
-  ) => {
-    updateQuestion(questionId, (question) => ({
-      ...question,
-      criteria: question.criteria.map((criterion) =>
-        criterion.id === criterionId ? { ...criterion, ...changes } : criterion,
-      ),
-    }));
-  };
-
-  const deleteCriterion = (questionId: string, criterionId: string) => {
-    updateQuestion(questionId, (question) => ({
-      ...question,
-      criteria: question.criteria.filter(
-        (criterion) => criterion.id !== criterionId,
-      ),
-    }));
   };
 
   const saveTemplate = useCallback(async () => {
@@ -279,7 +155,7 @@ const FRQEditorRenderer = ({
           frqTemplate.unitId,
           frqTemplate.id,
         ),
-        { ...currentPayload, updatedAt: serverTimestamp() },
+        toFirestoreUpdate(currentPayload),
       );
 
       // Re-baseline against exactly what was written, so an edit made while the
@@ -300,28 +176,9 @@ const FRQEditorRenderer = ({
     }
   }, [currentPayload, frqTemplate]);
 
-  // AdvancedTextbox treats its `questions[qIndex]` entry as a stable reference,
-  // so these must keep identity across unrelated re-renders instead of being
-  // rebuilt fresh. Both memos sit above the early return so hooks stay
-  // unconditional.
-  const descriptionQuestions = useMemo(
-    () => [createQuestionData(description)],
-    [description],
-  );
-
-  const questionFormats = useMemo(
-    () => questions.map((question) => question.questionData),
-    [questions],
-  );
-
-  const totalPoints = questions.reduce(
-    (total, question) =>
-      total +
-      getPartPoints({
-        id: question.id,
-        title: "",
-        criteria: question.criteria,
-      }),
+  const totalPoints = getEditorTotalPoints(questions);
+  const totalParts = questions.reduce(
+    (total, question) => total + question.parts.length,
     0,
   );
 
@@ -412,28 +269,60 @@ const FRQEditorRenderer = ({
               </div>
             </div>
 
+            <div className="mb-6">
+              <h2 className="text-sm font-semibold">Section heading</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Shown above the timer while students take this FRQ. Leave both
+                blank to keep the standard wording.
+              </p>
+
+              <div className="mt-3 grid gap-4 sm:grid-cols-2">
+                <div>
+                  <label
+                    htmlFor="frq-section-label"
+                    className="text-sm font-medium"
+                  >
+                    Section label
+                  </label>
+                  <Input
+                    id="frq-section-label"
+                    value={sectionLabel}
+                    onChange={(event) => setSectionLabel(event.target.value)}
+                    placeholder="Section II"
+                    className="mt-2"
+                  />
+                </div>
+
+                <div>
+                  <label
+                    htmlFor="frq-section-subtitle"
+                    className="text-sm font-medium"
+                  >
+                    Section subtitle
+                  </label>
+                  <Input
+                    id="frq-section-subtitle"
+                    value={sectionSubtitle}
+                    onChange={(event) => setSectionSubtitle(event.target.value)}
+                    placeholder="Free response"
+                    className="mt-2"
+                  />
+                </div>
+              </div>
+            </div>
+
             <div>
               <h1 className="text-xl font-semibold">FRQ Description</h1>
               <p className="mt-1 text-sm text-muted-foreground">
-                Add the source material and directions students need for this
-                FRQ. This is what students see beside the response box.
+                Directions that apply to the whole FRQ. Source material for a
+                single question belongs in that question&apos;s stimulus.
               </p>
 
               <div className="mt-4">
-                <AdvancedTextbox
+                <RichPromptEditor
                   key={`${frqTemplate.id}-description`}
-                  questions={descriptionQuestions}
-                  setQuestions={(updatedQuestions) => {
-                    const updatedDescription = updatedQuestions[0]?.question;
-
-                    if (!updatedDescription) {
-                      return;
-                    }
-
-                    setDescription(updatedDescription);
-                  }}
-                  origin="question"
-                  qIndex={0}
+                  value={description}
+                  onChange={setDescription}
                   placeholder="Enter the FRQ description here."
                 />
               </div>
@@ -445,7 +334,9 @@ const FRQEditorRenderer = ({
               <div>
                 <h2 className="text-xl font-semibold">Questions</h2>
                 <p className="mt-1 text-sm text-muted-foreground">
-                  {questions.length} questions in this FRQ
+                  {questions.length}{" "}
+                  {questions.length === 1 ? "question" : "questions"} &middot;{" "}
+                  {totalParts} {totalParts === 1 ? "part" : "parts"}
                 </p>
               </div>
 
@@ -465,281 +356,22 @@ const FRQEditorRenderer = ({
               className="space-y-4"
             >
               {questions.map((question, questionIndex) => (
-                <AccordionItem
+                <QuestionCard
                   key={question.id}
-                  value={question.id}
-                  data-frq-part={question.id}
-                  className="rounded-lg border bg-background px-4 shadow-sm"
-                >
-                  <AccordionTrigger
-                    variant="secondary"
-                    className="mr-0 py-4 hover:no-underline"
-                  >
-                    <div className="flex flex-1 items-center justify-between pr-3">
-                      <span className="flex items-center gap-2">
-                        <span className="font-semibold">
-                          {getPartLabel(questionIndex)}
-                        </span>
-
-                        {question.status === "legacy" && (
-                          <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                            Legacy
-                          </span>
-                        )}
-                      </span>
-                      <span className="text-sm font-normal text-muted-foreground">
-                        {formatPoints(
-                          getPartPoints({
-                            id: question.id,
-                            title: "",
-                            criteria: question.criteria,
-                          }),
-                        )}
-                      </span>
-                    </div>
-                  </AccordionTrigger>
-
-                  {/* ui/accordion.tsx hardcodes opacity-70 on the content root
-                      and routes className to an inner div, so there is no
-                      class-based override. Without this the editor's inputs all
-                      render washed out. Remove once accordion.tsx exposes it. */}
-                  <AccordionContent
-                    style={{ opacity: 1 }}
-                    className="space-y-5 pb-5 text-foreground"
-                  >
-                    <div>
-                      <label className="text-sm font-medium">
-                        Question prompt
-                      </label>
-                      <div className="mt-2">
-                        <AdvancedTextbox
-                          questions={questionFormats}
-                          // AdvancedTextbox hands back the whole array, but only
-                          // this question's entry is ours to write. An in-flight
-                          // file upload resolves against the array it captured
-                          // when the upload started, so copying every index back
-                          // would let a slow upload overwrite edits made to the
-                          // sibling questions in the meantime.
-                          setQuestions={(updatedQuestions) =>
-                            updateQuestion(question.id, (currentQuestion) => ({
-                              ...currentQuestion,
-                              questionData:
-                                updatedQuestions[questionIndex] ??
-                                currentQuestion.questionData,
-                            }))
-                          }
-                          origin="question"
-                          qIndex={questionIndex}
-                          placeholder="Enter the question prompt here."
-                        />
-                      </div>
-                    </div>
-
-                    {/* No question-level points field: the total is derived from
-                        the grading criteria below, which is what the grader
-                        actually awards against. */}
-                    <div className="grid gap-4 sm:grid-cols-2">
-                      <div>
-                        <label className="text-sm font-medium">
-                          Input type
-                        </label>
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button
-                              type="button"
-                              variant="outline"
-                              className="mt-2 w-full justify-between"
-                            >
-                              {question.answerType === "text"
-                                ? "Text"
-                                : "Equation"}
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="start">
-                            <DropdownMenuRadioGroup
-                              value={question.answerType}
-                              onValueChange={(value) => {
-                                if (value !== "text" && value !== "equation") {
-                                  return;
-                                }
-
-                                updateQuestion(
-                                  question.id,
-                                  (currentQuestion) => ({
-                                    ...currentQuestion,
-                                    answerType: value,
-                                  }),
-                                );
-                              }}
-                            >
-                              <DropdownMenuRadioItem value="text">
-                                Text
-                              </DropdownMenuRadioItem>
-                              <DropdownMenuRadioItem value="equation">
-                                Equation
-                              </DropdownMenuRadioItem>
-                            </DropdownMenuRadioGroup>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      </div>
-
-                      <div>
-                        <label className="text-sm font-medium">Status</label>
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button
-                              type="button"
-                              variant="outline"
-                              className="mt-2 w-full justify-between"
-                            >
-                              {question.status === "public"
-                                ? "Public"
-                                : "Legacy"}
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="start">
-                            <DropdownMenuRadioGroup
-                              value={question.status}
-                              onValueChange={(value) => {
-                                if (value !== "public" && value !== "legacy") {
-                                  return;
-                                }
-
-                                updateQuestion(
-                                  question.id,
-                                  (currentQuestion) => ({
-                                    ...currentQuestion,
-                                    status: value,
-                                  }),
-                                );
-                              }}
-                            >
-                              <DropdownMenuRadioItem value="public">
-                                Public
-                              </DropdownMenuRadioItem>
-                              <DropdownMenuRadioItem value="legacy">
-                                Legacy
-                              </DropdownMenuRadioItem>
-                            </DropdownMenuRadioGroup>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      </div>
-                    </div>
-
-                    <div className="flex flex-wrap items-center gap-2 border-t pt-4">
-                      <Button
-                        type="button"
-                        variant="outline"
-                        onClick={() => addCriterion(question.id)}
-                      >
-                        <Plus className="mr-2 size-4" />
-                        Add Criteria
-                      </Button>
-
-                      <Popover>
-                        <PopoverTrigger asChild>
-                          <Button
-                            type="button"
-                            variant="outline"
-                            aria-label="Question information"
-                            className="px-3"
-                          >
-                            <Info className="size-4" />
-                          </Button>
-                        </PopoverTrigger>
-
-                        <PopoverContent align="start" className="w-72 text-sm">
-                          A question&apos;s point total is calculated from its
-                          grading criteria. Graders award points against these
-                          exact lines.
-                        </PopoverContent>
-                      </Popover>
-
-                      <Button
-                        type="button"
-                        variant="outline"
-                        onClick={() => deleteQuestion(question.id)}
-                        title="Delete this question"
-                        className="ml-auto text-destructive"
-                      >
-                        <Trash2 className="mr-2 size-4" />
-                        Delete Question
-                      </Button>
-                    </div>
-
-                    <div className="space-y-3">
-                      <h3 className="text-sm font-semibold">
-                        Grading Criteria
-                      </h3>
-
-                      {question.criteria.length === 0 ? (
-                        <p className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
-                          No grading criteria have been added. A question with
-                          no criteria is worth zero points.
-                        </p>
-                      ) : (
-                        question.criteria.map((criterion, criterionIndex) => (
-                          <div
-                            key={criterion.id}
-                            className="grid gap-3 rounded-md border bg-muted/20 p-4 md:grid-cols-[minmax(0,1fr)_7rem_auto]"
-                          >
-                            <div>
-                              <label className="text-sm font-medium">
-                                Criterion {criterionIndex + 1}
-                              </label>
-                              <Textarea
-                                value={criterion.description}
-                                onChange={(event) =>
-                                  updateCriterion(question.id, criterion.id, {
-                                    description: event.target.value,
-                                  })
-                                }
-                                placeholder="Describe what earns these points."
-                                className="mt-2 min-h-24"
-                              />
-                            </div>
-
-                            <div>
-                              <label className="text-sm font-medium">
-                                Points
-                              </label>
-                              <Input
-                                type="number"
-                                min={0}
-                                step={1}
-                                value={criterion.points}
-                                onChange={(event) =>
-                                  updateCriterion(question.id, criterion.id, {
-                                    points: Math.max(
-                                      0,
-                                      Number(event.target.value) || 0,
-                                    ),
-                                  })
-                                }
-                                className="mt-2"
-                              />
-                            </div>
-
-                            <Button
-                              type="button"
-                              variant="outline"
-                              onClick={() =>
-                                deleteCriterion(question.id, criterion.id)
-                              }
-                              title="Delete criterion"
-                              aria-label={`Delete criterion ${
-                                criterionIndex + 1
-                              }`}
-                              className="mt-7 size-10 p-0 text-destructive"
-                            >
-                              <Trash2 className="size-4" />
-                            </Button>
-                          </div>
-                        ))
-                      )}
-                    </div>
-                  </AccordionContent>
-                </AccordionItem>
+                  question={question}
+                  index={questionIndex}
+                  onChange={(updater) => updateQuestion(question.id, updater)}
+                  onDelete={() => deleteQuestion(question.id)}
+                  onMovePart={(partId, direction) =>
+                    setQuestions((current) =>
+                      movePart(current, partId, direction),
+                    )
+                  }
+                  canMovePart={(partId, direction) =>
+                    canMovePart(questions, partId, direction)
+                  }
+                  canDelete={questions.length > 1}
+                />
               ))}
             </Accordion>
           </section>
@@ -747,10 +379,14 @@ const FRQEditorRenderer = ({
       </main>
 
       <FRQEditorFooter
-        parts={questions.map((question, index) => ({
-          id: question.id,
-          label: getPartLabel(index),
-        }))}
+        parts={questions.flatMap((question, questionIndex) =>
+          question.parts.map((part, partIndex) => ({
+            id: part.id,
+            // Part labels restart at A per question, so the jump-to grid needs
+            // the question number too for "1A" to be distinct from "2A".
+            label: `${questionIndex + 1}${getPartLabel(partIndex)}`,
+          })),
+        )}
         frqName={title.trim() || "Untitled FRQ"}
         visibility={isPublic ? "public" : "private"}
         hasUnsavedChanges={hasUnsavedChanges}

--- a/src/components/frq/editorRenderer.tsx
+++ b/src/components/frq/editorRenderer.tsx
@@ -7,10 +7,7 @@ import { Accordion } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { getFrqTemplateDocRef } from "@/lib/firestore/frqRefs";
-import type {
-  EditorQuestion,
-  EditorState,
-} from "@/lib/frq/editorState";
+import type { EditorQuestion, EditorState } from "@/lib/frq/editorState";
 import {
   buildInitialState,
   buildTemplatePayload,
@@ -41,7 +38,9 @@ type SaveState = "idle" | "saving" | "saved" | "error";
  * Deleting rather than storing `""` is also what keeps `normalizeFrqTemplate`'s
  * "absent means unconfigured" rule true of documents this editor writes.
  */
-const toFirestoreUpdate = (payload: ReturnType<typeof buildTemplatePayload>) => ({
+const toFirestoreUpdate = (
+  payload: ReturnType<typeof buildTemplatePayload>,
+) => ({
   ...payload,
   sectionLabel: payload.sectionLabel || deleteField(),
   sectionSubtitle: payload.sectionSubtitle || deleteField(),

--- a/src/lib/frq/editorState.ts
+++ b/src/lib/frq/editorState.ts
@@ -107,7 +107,9 @@ const toEditorQuestion = (question: FRQTemplateQuestion): EditorQuestion => ({
   parts: question.parts.map(toEditorPart),
 });
 
-export const buildInitialState = (template: FRQTemplate | null): EditorState => {
+export const buildInitialState = (
+  template: FRQTemplate | null,
+): EditorState => {
   const questions = (template?.questions ?? []).map(toEditorQuestion);
 
   return {
@@ -183,7 +185,11 @@ export const formatPoints = (points: number) =>
 
 /** Where a part currently sits, or null if no question holds it. */
 export const locatePart = (questions: EditorQuestion[], partId: string) => {
-  for (let questionIndex = 0; questionIndex < questions.length; questionIndex++) {
+  for (
+    let questionIndex = 0;
+    questionIndex < questions.length;
+    questionIndex++
+  ) {
     const partIndex =
       questions[questionIndex]?.parts.findIndex((part) => part.id === partId) ??
       -1;

--- a/src/lib/frq/editorState.ts
+++ b/src/lib/frq/editorState.ts
@@ -1,0 +1,287 @@
+import type {
+  FRQAnswerType,
+  FRQGradingCriterion,
+  FRQQuestionStatus,
+  FRQTemplate,
+  FRQTemplatePart,
+  FRQTemplateQuestion,
+} from "@/types/frq";
+import type { QuestionFormat, QuestionInput } from "@/types/questions";
+import {
+  DEFAULT_TIME_LIMIT_MINUTES,
+  getPartLabel,
+  getPartPoints,
+  makeId,
+  toQuestionInput,
+} from "./template.ts";
+
+/**
+ * The editor's own state shape, kept apart from the React component so the
+ * save format and the reordering rules can be tested directly. The round-trip
+ * suite used to re-implement `buildTemplatePayload` by hand to reach it, which
+ * meant the test could keep passing after the real save format drifted.
+ */
+
+/** One part as the editor holds it: stored fields plus its rich-text buffer. */
+export interface EditorPart {
+  id: string;
+  /** Prompt text and files, in the shape AdvancedTextbox reads and writes. */
+  prompt: QuestionFormat;
+  status: FRQQuestionStatus;
+  answerType: FRQAnswerType;
+  criteria: FRQGradingCriterion[];
+}
+
+/** One numbered question: its own stimulus plus the parts hanging off it. */
+export interface EditorQuestion {
+  id: string;
+  /** Stimulus text and files, same rich-text shape as a part's prompt. */
+  stimulus: QuestionFormat;
+  parts: EditorPart[];
+}
+
+export interface EditorState {
+  title: string;
+  /** Exam-wide directions. Stays separate from any one question's stimulus. */
+  description: QuestionFormat;
+  sectionLabel: string;
+  sectionSubtitle: string;
+  questions: EditorQuestion[];
+  timeLimitMinutes: number;
+  isPublic: boolean;
+}
+
+export const createQuestionInput = (value = ""): QuestionInput => ({
+  value,
+  files: [],
+});
+
+/**
+ * AdvancedTextbox only ever reads `question` here, but it spreads the whole
+ * record on every edit, so the unused fields have to exist to survive a save.
+ */
+export const createQuestionData = (
+  question = createQuestionInput(),
+): QuestionFormat => ({
+  question,
+  type: "frq",
+  options: [],
+  answers: [],
+  explanation: createQuestionInput(),
+  content: createQuestionInput(),
+  topic: "",
+});
+
+export const createEditorPart = (): EditorPart => ({
+  id: makeId("part"),
+  prompt: createQuestionData(),
+  status: "public",
+  answerType: "text",
+  criteria: [],
+});
+
+/**
+ * A new question starts with no parts. The author adds the first one, which
+ * keeps a half-built question out of the saved document: `getStudentFacing-
+ * Questions` drops a question whose parts are all hidden anyway.
+ */
+export const createEditorQuestion = (): EditorQuestion => ({
+  id: makeId("question"),
+  stimulus: createQuestionData(),
+  parts: [],
+});
+
+const toEditorPart = (part: FRQTemplatePart): EditorPart => ({
+  id: part.id,
+  prompt: createQuestionData(toQuestionInput(part.prompt, part.promptFiles)),
+  status: part.status ?? "public",
+  answerType: part.answerType ?? "text",
+  criteria: part.criteria ?? [],
+});
+
+const toEditorQuestion = (question: FRQTemplateQuestion): EditorQuestion => ({
+  id: question.id,
+  stimulus: createQuestionData(
+    toQuestionInput(question.stimulus, question.stimulusFiles),
+  ),
+  parts: question.parts.map(toEditorPart),
+});
+
+export const buildInitialState = (template: FRQTemplate | null): EditorState => {
+  const questions = (template?.questions ?? []).map(toEditorQuestion);
+
+  return {
+    title: template?.title ?? "",
+    description: createQuestionData(
+      toQuestionInput(template?.directions, template?.directionsFiles),
+    ),
+    // "" rather than the hardcoded default: an untouched field must still save
+    // as absent, so that a template nobody configured keeps falling back
+    // instead of freezing today's wording into the document.
+    sectionLabel: template?.sectionLabel ?? "",
+    sectionSubtitle: template?.sectionSubtitle ?? "",
+    // An FRQ with no questions still needs somewhere to put the first part.
+    questions: questions.length > 0 ? questions : [createEditorQuestion()],
+    timeLimitMinutes: template?.timeLimitMinutes ?? DEFAULT_TIME_LIMIT_MINUTES,
+    isPublic: template?.isPublic === true,
+  };
+};
+
+/**
+ * The exact document body a save writes, minus the server timestamp. Unsaved
+ * state is detected by comparing this against the last persisted version rather
+ * than by watching for state updates: React StrictMode double-invokes effects
+ * in development, and the rich-text children re-emit equal values on mount, so
+ * a "something changed" listener reported unsaved work before any edit.
+ */
+export const buildTemplatePayload = (state: EditorState) => ({
+  title: state.title.trim() || "Untitled FRQ",
+  directions: state.description.question.value,
+  directionsFiles: state.description.question.files,
+  sectionLabel: state.sectionLabel.trim(),
+  sectionSubtitle: state.sectionSubtitle.trim(),
+  timeLimitMinutes: state.timeLimitMinutes,
+  isPublic: state.isPublic,
+  questions: state.questions.map((question) => ({
+    id: question.id,
+    stimulus: question.stimulus.question.value,
+    stimulusFiles: question.stimulus.question.files,
+    parts: question.parts.map((part, index) => ({
+      id: part.id,
+      // Labels are positional and recomputed on every save, so a part that
+      // moved to another question is relabelled without its id changing.
+      title: getPartLabel(index),
+      prompt: part.prompt.question.value,
+      promptFiles: part.prompt.question.files,
+      answerType: part.answerType,
+      status: part.status,
+      criteria: part.criteria,
+    })),
+  })),
+});
+
+/**
+ * A part is worth the sum of its rubric lines and nothing else, which is the
+ * rule the grading page and the student's feedback page also apply. `title` is
+ * the one field `getPartPoints` does not read, so the shim stays here rather
+ * than at every call site.
+ */
+export const getEditorPartPoints = (part: EditorPart) =>
+  getPartPoints({ id: part.id, title: "", criteria: part.criteria });
+
+export const getEditorQuestionPoints = (question: EditorQuestion) =>
+  question.parts.reduce((total, part) => total + getEditorPartPoints(part), 0);
+
+export const getEditorTotalPoints = (questions: EditorQuestion[]) =>
+  questions.reduce(
+    (total, question) => total + getEditorQuestionPoints(question),
+    0,
+  );
+
+export const formatPoints = (points: number) =>
+  `${points} ${points === 1 ? "point" : "points"}`;
+
+/** Where a part currently sits, or null if no question holds it. */
+export const locatePart = (questions: EditorQuestion[], partId: string) => {
+  for (let questionIndex = 0; questionIndex < questions.length; questionIndex++) {
+    const partIndex =
+      questions[questionIndex]?.parts.findIndex((part) => part.id === partId) ??
+      -1;
+
+    if (partIndex !== -1) {
+      return { questionIndex, partIndex };
+    }
+  }
+
+  return null;
+};
+
+/**
+ * Move a part one slot, crossing into the neighbouring question when it runs
+ * off either end. This is how an author splits a flat legacy FRQ into real
+ * questions: the part object travels intact, so the id that every stored
+ * response and grade resolves through is unchanged by the move. Rebuilding the
+ * part instead would orphan its submissions.
+ */
+export const movePart = (
+  questions: EditorQuestion[],
+  partId: string,
+  direction: -1 | 1,
+): EditorQuestion[] => {
+  const location = locatePart(questions, partId);
+
+  if (!location) {
+    return questions;
+  }
+
+  const { questionIndex, partIndex } = location;
+  const source = questions[questionIndex];
+  const part = source?.parts[partIndex];
+
+  if (!source || !part) {
+    return questions;
+  }
+
+  const targetIndex = partIndex + direction;
+
+  // Still inside the same question: swap with the neighbouring part.
+  if (targetIndex >= 0 && targetIndex < source.parts.length) {
+    const parts = [...source.parts];
+    parts[partIndex] = parts[targetIndex]!;
+    parts[targetIndex] = part;
+
+    return questions.map((question, index) =>
+      index === questionIndex ? { ...question, parts } : question,
+    );
+  }
+
+  const neighbourIndex = questionIndex + direction;
+
+  // Already the first part of the first question, or the last of the last.
+  if (neighbourIndex < 0 || neighbourIndex >= questions.length) {
+    return questions;
+  }
+
+  return questions.map((question, index) => {
+    if (index === questionIndex) {
+      return {
+        ...question,
+        parts: question.parts.filter((candidate) => candidate.id !== partId),
+      };
+    }
+
+    if (index === neighbourIndex) {
+      // Moving up lands at the end of the question above and moving down at the
+      // start of the one below, so the part holds its place in reading order.
+      return {
+        ...question,
+        parts:
+          direction === -1
+            ? [...question.parts, part]
+            : [part, ...question.parts],
+      };
+    }
+
+    return question;
+  });
+};
+
+/** Whether a part has anywhere to go, used to disable the move buttons. */
+export const canMovePart = (
+  questions: EditorQuestion[],
+  partId: string,
+  direction: -1 | 1,
+): boolean => {
+  const location = locatePart(questions, partId);
+
+  if (!location) {
+    return false;
+  }
+
+  const { questionIndex, partIndex } = location;
+
+  return direction === -1
+    ? questionIndex > 0 || partIndex > 0
+    : questionIndex < questions.length - 1 ||
+        partIndex < (questions[questionIndex]?.parts.length ?? 0) - 1;
+};

--- a/src/lib/frq/editorState.ts
+++ b/src/lib/frq/editorState.ts
@@ -51,7 +51,7 @@ export interface EditorState {
   isPublic: boolean;
 }
 
-export const createQuestionInput = (value = ""): QuestionInput => ({
+const createQuestionInput = (value = ""): QuestionInput => ({
   value,
   files: [],
 });
@@ -60,7 +60,7 @@ export const createQuestionInput = (value = ""): QuestionInput => ({
  * AdvancedTextbox only ever reads `question` here, but it spreads the whole
  * record on every edit, so the unused fields have to exist to survive a save.
  */
-export const createQuestionData = (
+const createQuestionData = (
   question = createQuestionInput(),
 ): QuestionFormat => ({
   question,
@@ -201,6 +201,49 @@ export const locatePart = (questions: EditorQuestion[], partId: string) => {
 
   return null;
 };
+
+/**
+ * Apply an edit to a part wherever it currently lives.
+ *
+ * Addressed by part id rather than by "question X, part Y" on purpose. Parts
+ * change parent now, and an edit can land after the move: a file upload that
+ * started in question 1 resolves seconds later, by which point the author may
+ * have moved that part into question 2. Routing through the question it used
+ * to sit in would match nothing and drop the upload's download URL, leaving a
+ * file that exists in Storage but renders blank for every student.
+ *
+ * Questions that do not hold the part keep their identity, so an edit to one
+ * part does not force every other question card to re-render.
+ */
+export const updatePartById = (
+  questions: EditorQuestion[],
+  partId: string,
+  updater: (part: EditorPart) => EditorPart,
+): EditorQuestion[] =>
+  questions.map((question) =>
+    question.parts.some((part) => part.id === partId)
+      ? {
+          ...question,
+          parts: question.parts.map((part) =>
+            part.id === partId ? updater(part) : part,
+          ),
+        }
+      : question,
+  );
+
+/** Remove a part from whichever question holds it. */
+export const deletePartById = (
+  questions: EditorQuestion[],
+  partId: string,
+): EditorQuestion[] =>
+  questions.map((question) =>
+    question.parts.some((part) => part.id === partId)
+      ? {
+          ...question,
+          parts: question.parts.filter((part) => part.id !== partId),
+        }
+      : question,
+  );
 
 /**
  * Move a part one slot, crossing into the neighbouring question when it runs

--- a/src/lib/frq/template.ts
+++ b/src/lib/frq/template.ts
@@ -14,6 +14,19 @@ export const DEFAULT_TIME_LIMIT_MINUTES = 90;
 const asString = (value: unknown): string =>
   typeof value === "string" ? value : "";
 
+/**
+ * For fields the type marks optional, where absent carries meaning. Blank
+ * collapses to absent so the field is only ever a non-empty string or missing,
+ * which is what lets a consumer use `??` and `||` interchangeably: against a
+ * stored `""` the two disagree, and `sectionLabel ?? "Section II"` would render
+ * a blank heading for a template nobody ever configured.
+ */
+const asOptionalString = (value: unknown): string | undefined => {
+  const text = typeof value === "string" ? value.trim() : "";
+
+  return text === "" ? undefined : text;
+};
+
 const asRecord = (value: unknown): Record<string, unknown> | null =>
   typeof value === "object" && value !== null && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -198,15 +211,13 @@ export const normalizeFrqTemplate = (
   const record = asRecord(raw) ?? {};
   const timeLimit = Number(record.timeLimitMinutes);
 
-  return {
+  const template: FRQTemplate = {
     id: identity.id,
     subject: asString(record.subject) || identity.subject,
     unitId: asString(record.unitId) || identity.unitId,
     title: asString(record.title) || "Untitled FRQ",
     directions: asString(record.directions),
     directionsFiles: normalizeFiles(record.directionsFiles),
-    sectionLabel: asString(record.sectionLabel),
-    sectionSubtitle: asString(record.sectionSubtitle),
     questions: normalizeQuestions(record.questions),
     isPublic: record.isPublic === true,
     timeLimitMinutes:
@@ -214,6 +225,16 @@ export const normalizeFrqTemplate = (
         ? Math.floor(timeLimit)
         : DEFAULT_TIME_LIMIT_MINUTES,
   };
+
+  // Assigned only when configured, so the key is genuinely missing on a
+  // template that predates section headings rather than present-and-blank.
+  const sectionLabel = asOptionalString(record.sectionLabel);
+  const sectionSubtitle = asOptionalString(record.sectionSubtitle);
+
+  if (sectionLabel) template.sectionLabel = sectionLabel;
+  if (sectionSubtitle) template.sectionSubtitle = sectionSubtitle;
+
+  return template;
 };
 
 export const toQuestionInput = (


### PR DESCRIPTION
## Goal

PR 1 added the nested `Template -> Question -> Part` model. Nothing could author it. The admin editor still held one flat list of parts and wrote it back wrapped in a single hardcoded question, so a second question had nowhere to live and no author could reach a stimulus.

This PR adds the second level to the editor. Authors can build a real multi-question exam and write the section heading PR 1 made configurable.

## What changes here

Each question becomes a card owning its own stimulus and holding a nested list of parts. Part labels restart at A inside every question, the way AP numbers them, so an exam reads 1A, 1B, 2A instead of A, B, C.

The left pane gains the `sectionLabel` and `sectionSubtitle` fields. PR 1 added both to `FRQTemplate` and left them unreachable. Their placeholders show the wording students see today, so an author can tell what leaving them blank produces.

`buildTemplatePayload` writes the structure the author built. PR 1's version always emitted exactly one question with the id `legacy-question`, which is the collapse its sequencing note described. That note no longer applies.

## Moving parts between questions

An author splitting an existing flat FRQ into real questions has to preserve part ids. `responses` is keyed by part id, and `FRQQuestionGrade.questionId` stores a part id. Without a way to move a part, the only route from one flat FRQ to three questions is deleting each part and retyping it, which mints a new id and orphans every submission and grade pointing at the old one.

So the move buttons cross question boundaries. Moving a part down past the last part of question 1 lands it at the top of question 2. The part object travels intact. Only `title` changes, because labels are positional and `buildTemplatePayload` recomputes them on every save.

Parts changing parent is also what forced every part handler to take a part id rather than a question id. An edit can land after the move: an upload that began in question 1 resolves once the part already sits in question 2, and a handler scoped to the question it used to occupy would match nothing and drop the download URL. `updatePartById` and `deletePartById` search for the part instead, and leave untouched questions holding their identity so one keystroke does not re-render every card.

Whole questions do not reorder. Nobody asked for it, and it adds boundary cases to logic that already handles four.

## The AdvancedTextbox hazard, and the half of it still open

PR 1 named this as the thing to watch in review. `AdvancedTextbox` reads `questions[qIndex]` and calls `setQuestions` with the entire array, rebuilt from the array it captured when the change began. A file upload resolves seconds later against that stale copy, so writing all of it back drops edits made to sibling entries in between. The flat editor worked around it by reading back only its own index.

Nesting parts inside questions would have recreated the same problem one level up. `richPromptEditor.tsx` hands every rich-text field its own one-entry array with `qIndex={0}`. Overwriting a sibling takes a sibling in the array, and no field has one now. The description, each question stimulus and each part prompt all go through that wrapper.

That covers one field clobbering another. It does not cover a field clobbering itself, and review caught me claiming otherwise. `updateQuestionsWithFiles` rebuilds the value from the `questionInstance` its closure captured, so text you type while an upload is in flight gets reverted when that upload lands: type a sentence during an 8-second image upload and watch it vanish from the box, with no error and no undo. That bug predates this PR and the flat editor had it too. Closing it means changing how `AdvancedTextbox` writes back, which every article-creator screen also depends on, so it does not belong in this PR. The comment in `richPromptEditor.tsx` now says exactly which half it covers, so the next reader does not skip past it.

Two related pre-existing behaviours, both worth knowing before PR 3:

- Collapsing a question unmounts every `AdvancedTextbox` under it and kills any upload in flight. One click now costs N uploads instead of one, because there is a second nesting level. Fixing it needs `forceMount` on the shared `ui/accordion.tsx`.
- `AdvancedTextbox` calls `updateQuestionsWithFiles` inside a `setUploadedFiles` updater, so StrictMode fires the parent update twice in development.

## Clearing a section heading

Firestore rejects `undefined`, and `updateDoc` leaves untouched any key you omit. Sending neither would strand the previous heading in the document after an author cleared the field, so `toFirestoreUpdate` sends `deleteField()` for a blank one. That also holds `normalizeFrqTemplate` to its rule: an absent key means nobody configured a heading.

That rule needed a fix, which this PR carries. `normalizeFrqTemplate` ran both heading fields through `asString`, so a field nobody ever wrote came back as `""`. A consumer reaching for the fallback with `sectionLabel ?? "Section II"` would have rendered a blank heading. Both fields now normalize to a non-empty string or nothing at all.

## Structure

The editor moved out of one 763-line component into four files, each under the 500-line limit:

- `src/lib/frq/editorState.ts` holds the state shape, the save format and the reordering rules. No React and no Firestore, so tests call it directly.
- `editorRenderer.tsx` keeps state, the save and the layout.
- `editor/questionCard.tsx` and `editor/partCard.tsx` render one level each.
- `editor/richPromptEditor.tsx` wraps `AdvancedTextbox`.

## Sequencing

This PR lifts PR 1's constraint and introduces a smaller one.

Authors can now build multi-question exams. The student and grading pages still call `getAllParts`, which flattens every part across every question, so a question's stimulus renders nowhere and the boundary between question 1 and question 2 disappears. PR 3 and PR 4 fix each side.

No document loses data. Structure survives a save and reloads intact. The exposure is wrong rendering, and only if `frq` reaches production between this PR and PR 3.

## Accordion state

Radix reads `defaultValue` once at mount, which made three things break for anything created after that. "Add Part" produced a collapsed header row at the bottom of a scrolled list, so the button read as broken. "Add Question" did the same. Worst, a part moved into a collapsed question left the page entirely at the moment you moved it, which is a poor first impression for the feature this PR exists to add.

Both accordions are controlled now. One list of open part ids covers the whole document, since part ids are unique within one. Each question's accordion reports only the parts it owns, so it carries the other questions' ids across its own change; without that, opening one part would collapse every other question's parts.

The footer's jump-to-part grid needed the same fix from the other direction. A part sits inside its question's panel, so while that question is collapsed the part is not in the DOM and `?.scrollIntoView` swallowed the miss: the button stayed visible, stayed labelled 2A and did nothing. The editor now opens the question and the part, then scrolls once the item mounts.

## Testing

`npm test` 34/34, `npx tsc --noEmit` clean, `npm run lint` clean, `npm run build` succeeds.

The round-trip suite now imports the real `buildTemplatePayload`. It used to re-implement that function by hand, so it could have kept passing after the editor started writing something else. All 21 tests from PR 1 still pass against the real thing, which is what shows this save format round-trips legacy documents the way PR 1's did.

13 new tests cover the second level: a two-question document surviving load, save and reload with both stimuli and every part id; labels restarting at A per question; a part keeping its object identity and rubric across a move; an edit landing on a part after it changed question; both boundary directions refusing to move; an empty FRQ opening with somewhere to add a part; and an empty question saving as the nested shape rather than being re-read as legacy.

## What PRs 3 and 4 cover

**PR 3, taking the test.** Students page between questions instead of parts, and a question's parts stack on one page with that question's stimulus in the left pane. The header reads the authored section label. All three tester complaints resolve here.

**PR 4, grading and feedback.** Graders page by question with that question's parts and rubrics beside them. `buildFeedbackDocument` stops hardcoding a single-entry array. The feedback UI already models questions containing parts, so it needs no changes.
